### PR TITLE
Changed signature of catalogDeregister to accept a single CatalogDere…

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/ConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulClient.java
@@ -203,8 +203,8 @@ public final class ConsulClient implements AclClient, AgentClient, CatalogClient
 	}
 
 	@Override
-	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration, CatalogDeregistration... catalogDeregistrations) {
-		return catalogClient.catalogDeregister(catalogDeregistration, catalogDeregistrations);
+	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration) {
+		return catalogClient.catalogDeregister(catalogDeregistration);
 	}
 
 	@Override

--- a/src/main/java/com/ecwid/consul/v1/catalog/CatalogClient.java
+++ b/src/main/java/com/ecwid/consul/v1/catalog/CatalogClient.java
@@ -17,7 +17,7 @@ public interface CatalogClient {
 
 	public Response<Void> catalogRegister(CatalogRegistration catalogRegistration);
 
-	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration, CatalogDeregistration... catalogDeregistrations);
+	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration);
 
 	public Response<List<String>> getCatalogDatacenters();
 

--- a/src/main/java/com/ecwid/consul/v1/catalog/CatalogConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/catalog/CatalogConsulClient.java
@@ -55,13 +55,8 @@ public final class CatalogConsulClient implements CatalogClient {
 	}
 
 	@Override
-	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration, CatalogDeregistration... catalogDeregistrations) {
-		List<CatalogDeregistration> items = new ArrayList<CatalogDeregistration>();
-		items.add(catalogDeregistration);
-		if (catalogDeregistrations != null) {
-			items.addAll(Arrays.asList(catalogDeregistrations));
-		}
-		String json = GsonFactory.getGson().toJson(items);
+	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration) {
+		String json = GsonFactory.getGson().toJson(catalogDeregistration);
 
 		RawResponse rawResponse = rawClient.makePutRequest("/v1/catalog/deregister", json);
 		if (rawResponse.getStatusCode() == 200) {


### PR DESCRIPTION
I'm getting the following stack trace when trying to use catalogDeregister:

Exception in thread "main" OperationException{statusCode=400, statusMessage='Bad Request'}
	at com.ecwid.consul.v1.catalog.CatalogConsulClient.catalogDeregister(CatalogConsulClient.java:70)
	at com.ecwid.consul.v1.ConsulClient.catalogDeregister(ConsulClient.java:191)

The response from the server is "Request decode failed: '' expected a map, got 'slice'"  I forked the code and just sent the first argument to catalogDeregister and it worked fine.  Is there a reason why catalogDeregister has a varargs signature?  It seems like it should only accept a single CatalogDeregistration argument.