### PR TITLE
Support to connect to consul using TLS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def doUploadArchives = project.hasProperty('sonatypeUsername') && project.hasPro
 if (doUploadArchives) {
 	group = "com.ecwid.consul"
 	archivesBaseName = "consul-api"
-	version = "1.1.6"
+	version = "1.1.7"
 
 	signing {
 		sign configurations.archives

--- a/src/main/java/com/ecwid/consul/transport/AbstractHttpTransport.java
+++ b/src/main/java/com/ecwid/consul/transport/AbstractHttpTransport.java
@@ -1,0 +1,108 @@
+package com.ecwid.consul.transport;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+
+public class AbstractHttpTransport implements HttpTransport {
+
+    protected final HttpClient httpClient;
+
+    public AbstractHttpTransport() {
+	PoolingClientConnectionManager connectionManager = new PoolingClientConnectionManager();
+	connectionManager.setMaxTotal(1000);
+	connectionManager.setDefaultMaxPerRoute(500);
+
+	this.httpClient = new DefaultHttpClient(connectionManager);
+    }
+
+    public AbstractHttpTransport(HttpClient httpClient) {
+	this.httpClient = httpClient;
+    }
+
+    @Override
+    public RawResponse makeGetRequest(String url) {
+	HttpGet httpGet = new HttpGet(url);
+	return executeRequest(httpGet);
+    }
+
+    @Override
+    public RawResponse makePutRequest(String url, String content) {
+	HttpPut httpPut = new HttpPut(url);
+	httpPut.setEntity(new StringEntity(content, Charset.forName("UTF-8")));
+	return executeRequest(httpPut);
+    }
+
+    @Override
+    public RawResponse makePutRequest(String url, byte[] content) {
+	HttpPut httpPut = new HttpPut(url);
+	httpPut.setEntity(new ByteArrayEntity(content));
+	return executeRequest(httpPut);
+    }
+
+    @Override
+    public RawResponse makeDeleteRequest(String url) {
+	HttpDelete httpDelete = new HttpDelete(url);
+	return executeRequest(httpDelete);
+    }
+
+    private RawResponse executeRequest(HttpUriRequest httpRequest) {
+	try {
+	    return httpClient.execute(httpRequest, new ResponseHandler<RawResponse>() {
+		@Override
+		public RawResponse handleResponse(HttpResponse response) throws IOException {
+		    int statusCode = response.getStatusLine().getStatusCode();
+		    String statusMessage = response.getStatusLine().getReasonPhrase();
+
+		    String content = EntityUtils.toString(response.getEntity(), Charset.forName("UTF-8"));
+
+		    Long consulIndex = parseLong(response.getFirstHeader("X-Consul-Index"));
+		    Boolean consulKnownLeader = parseBoolean(response.getFirstHeader("X-Consul-Knownleader"));
+		    Long consulLastContact = parseLong(response.getFirstHeader("X-Consul-Lastcontact"));
+
+		    return new RawResponse(statusCode, statusMessage, content, consulIndex, consulKnownLeader, consulLastContact);
+		}
+	    });
+	} catch (IOException e) {
+	    throw new TransportException(e);
+	}
+    }
+
+    private Long parseLong(Header header) {
+	try {
+	    return Long.parseLong(header.getValue());
+	} catch (Exception e) {
+	    return null;
+	}
+    }
+
+    private Boolean parseBoolean(Header header) {
+	if (header == null) {
+	    return null;
+	}
+
+	if ("true".equals(header.getValue())) {
+	    return true;
+	}
+
+	if ("false".equals(header.getValue())) {
+	    return false;
+	}
+
+	return null;
+    }
+
+}

--- a/src/main/java/com/ecwid/consul/transport/DefaultHttpTransport.java
+++ b/src/main/java/com/ecwid/consul/transport/DefaultHttpTransport.java
@@ -1,115 +1,20 @@
 package com.ecwid.consul.transport;
 
-import org.apache.http.Header;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.PoolingClientConnectionManager;
-import org.apache.http.params.HttpParams;
-import org.apache.http.util.EntityUtils;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
 
 /**
- * Default HTTP client
- * This class is thread safe
+ * Default HTTP client This class is thread safe
  *
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
-public final class DefaultHttpTransport implements HttpTransport {
+public final class DefaultHttpTransport extends AbstractHttpTransport {
 
-	private final HttpClient httpClient;
+    public DefaultHttpTransport() {
+	super();
+    }
 
-	public DefaultHttpTransport() {
-		PoolingClientConnectionManager connectionManager = new PoolingClientConnectionManager();
-		connectionManager.setMaxTotal(1000);
-		connectionManager.setDefaultMaxPerRoute(500);
-
-		this.httpClient = new DefaultHttpClient(connectionManager);
-	}
-
-	public DefaultHttpTransport(HttpClient httpClient) {
-		this.httpClient = httpClient;
-	}
-
-	@Override
-	public RawResponse makeGetRequest(String url) {
-		HttpGet httpGet = new HttpGet(url);
-		return executeRequest(httpGet);
-	}
-
-	@Override
-	public RawResponse makePutRequest(String url, String content) {
-		HttpPut httpPut = new HttpPut(url);
-		httpPut.setEntity(new StringEntity(content, Charset.forName("UTF-8")));
-		return executeRequest(httpPut);
-	}
-
-	@Override
-	public RawResponse makePutRequest(String url, byte[] content) {
-		HttpPut httpPut = new HttpPut(url);
-		httpPut.setEntity(new ByteArrayEntity(content));
-		return executeRequest(httpPut);
-	}
-
-	@Override
-	public RawResponse makeDeleteRequest(String url) {
-		HttpDelete httpDelete = new HttpDelete(url);
-		return executeRequest(httpDelete);
-	}
-
-	private RawResponse executeRequest(HttpUriRequest httpRequest) {
-		try {
-			return httpClient.execute(httpRequest, new ResponseHandler<RawResponse>() {
-				@Override
-				public RawResponse handleResponse(HttpResponse response) throws IOException {
-					int statusCode = response.getStatusLine().getStatusCode();
-					String statusMessage = response.getStatusLine().getReasonPhrase();
-
-					String content = EntityUtils.toString(response.getEntity(), Charset.forName("UTF-8"));
-
-					Long consulIndex = parseLong(response.getFirstHeader("X-Consul-Index"));
-					Boolean consulKnownLeader = parseBoolean(response.getFirstHeader("X-Consul-Knownleader"));
-					Long consulLastContact = parseLong(response.getFirstHeader("X-Consul-Lastcontact"));
-
-					return new RawResponse(statusCode, statusMessage, content, consulIndex, consulKnownLeader, consulLastContact);
-				}
-			});
-		} catch (IOException e) {
-			throw new TransportException(e);
-		}
-	}
-
-	private Long parseLong(Header header) {
-		try {
-			return Long.parseLong(header.getValue());
-		} catch (Exception e) {
-			return null;
-		}
-	}
-
-	private Boolean parseBoolean(Header header) {
-		if (header == null) {
-			return null;
-		}
-
-		if ("true".equals(header.getValue())) {
-			return true;
-		}
-
-		if ("false".equals(header.getValue())) {
-			return false;
-		}
-
-		return null;
-	}
+    public DefaultHttpTransport(HttpClient httpClient) {
+	super(httpClient);
+    }
 
 }

--- a/src/main/java/com/ecwid/consul/transport/DefaultHttpsTransport.java
+++ b/src/main/java/com/ecwid/consul/transport/DefaultHttpsTransport.java
@@ -1,0 +1,69 @@
+package com.ecwid.consul.transport;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+
+import com.ecwid.consul.transport.TLSConfig.KeyStoreInstanceType;
+
+/**
+ * Default HTTPS client This class is thread safe
+ *
+ * @author Carlos Augusto Ribeiro Mantovani (gutomantovani@gmail.com)
+ */
+public final class DefaultHttpsTransport extends AbstractHttpTransport {
+
+    public DefaultHttpsTransport(TLSConfig tlsConfig) {
+
+	KeyStore clientStore;
+	try {
+	    clientStore = KeyStore.getInstance(tlsConfig.getKeyStoreInstanceType().name());
+
+	    clientStore.load(new FileInputStream(tlsConfig.getCertficatePath()), tlsConfig.getCertificatePassword().toCharArray());
+
+	    KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+	    kmf.init(clientStore, "".toCharArray());
+	    KeyManager[] kms = kmf.getKeyManagers();
+
+	    KeyStore trustStore = KeyStore.getInstance(KeyStoreInstanceType.JKS.name());
+	    trustStore.load(new FileInputStream(tlsConfig.getKeyStorePath()), tlsConfig.getKeyStorePassword().toCharArray());
+
+	    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+	    tmf.init(trustStore);
+	    TrustManager[] tms = tmf.getTrustManagers();
+
+	    SSLContext sslContext = null;
+	    sslContext = SSLContext.getInstance("TLS");
+	    sslContext.init(kms, tms, new SecureRandom());
+
+	    SSLSocketFactory sf = new SSLSocketFactory(sslContext);
+	    Scheme sch = new Scheme("https", sf, tlsConfig.getSslPort());
+	    this.httpClient.getConnectionManager().getSchemeRegistry().register(sch);
+
+	} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException | UnrecoverableKeyException
+	        | KeyManagementException e) {
+	    throw new TransportException(e);
+	}
+    }
+
+    public DefaultHttpsTransport(HttpClient httpClient) {
+	super(httpClient);
+    }
+
+}

--- a/src/main/java/com/ecwid/consul/transport/DefaultHttpsTransport.java
+++ b/src/main/java/com/ecwid/consul/transport/DefaultHttpsTransport.java
@@ -1,6 +1,7 @@
 package com.ecwid.consul.transport;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -56,8 +57,19 @@ public final class DefaultHttpsTransport extends AbstractHttpTransport {
 	    Scheme sch = new Scheme("https", sf, tlsConfig.getSslPort());
 	    this.httpClient.getConnectionManager().getSchemeRegistry().register(sch);
 
-	} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException | UnrecoverableKeyException
-	        | KeyManagementException e) {
+	} catch (KeyStoreException e) {
+	    throw new TransportException(e);
+	} catch (NoSuchAlgorithmException e) {
+	    throw new TransportException(e);
+	} catch (CertificateException e) {
+	    throw new TransportException(e);
+	} catch (FileNotFoundException e) {
+	    throw new TransportException(e);
+	} catch (IOException e) {
+	    throw new TransportException(e);
+	} catch (UnrecoverableKeyException e) {
+	    throw new TransportException(e);
+	} catch (KeyManagementException e) {
 	    throw new TransportException(e);
 	}
     }

--- a/src/main/java/com/ecwid/consul/transport/TLSConfig.java
+++ b/src/main/java/com/ecwid/consul/transport/TLSConfig.java
@@ -1,0 +1,80 @@
+package com.ecwid.consul.transport;
+
+public class TLSConfig {
+
+    public enum KeyStoreInstanceType {
+	JKS, JCEKS, PKCS12, PKCS11, DKS
+    }
+
+    private KeyStoreInstanceType keyStoreInstanceType;
+
+    private String certficatePath;
+
+    private String certificatePassword;
+
+    private String keyStorePath;
+
+    private String keyStorePassword;
+
+    private int sslPort;
+
+    public TLSConfig(KeyStoreInstanceType keyStoreInstanceType, String certficatePath, String certificatePassword, String keyStorePath,
+            String keyStorePassword, int sslPort) {
+	super();
+	this.keyStoreInstanceType = keyStoreInstanceType;
+	this.certficatePath = certficatePath;
+	this.certificatePassword = certificatePassword;
+	this.keyStorePath = keyStorePath;
+	this.keyStorePassword = keyStorePassword;
+	this.sslPort = sslPort;
+    }
+
+    public KeyStoreInstanceType getKeyStoreInstanceType() {
+	return keyStoreInstanceType;
+    }
+
+    public void setKeyStoreInstanceType(KeyStoreInstanceType keyStoreInstanceType) {
+	this.keyStoreInstanceType = keyStoreInstanceType;
+    }
+
+    public String getCertficatePath() {
+	return certficatePath;
+    }
+
+    public void setCertficatePath(String certficatePath) {
+	this.certficatePath = certficatePath;
+    }
+
+    public String getCertificatePassword() {
+	return certificatePassword;
+    }
+
+    public void setCertificatePassword(String certificatePassword) {
+	this.certificatePassword = certificatePassword;
+    }
+
+    public String getKeyStorePath() {
+	return keyStorePath;
+    }
+
+    public void setKeyStorePath(String keyStorePath) {
+	this.keyStorePath = keyStorePath;
+    }
+
+    public String getKeyStorePassword() {
+	return keyStorePassword;
+    }
+
+    public void setKeyStorePassword(String keyStorePassword) {
+	this.keyStorePassword = keyStorePassword;
+    }
+
+    public int getSslPort() {
+	return sslPort;
+    }
+
+    public void setSslPort(int sslPort) {
+	this.sslPort = sslPort;
+    }
+
+}

--- a/src/main/java/com/ecwid/consul/v1/ConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulClient.java
@@ -1,5 +1,9 @@
 package com.ecwid.consul.v1;
 
+import java.util.List;
+import java.util.Map;
+
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.acl.AclClient;
 import com.ecwid.consul.v1.acl.AclConsulClient;
 import com.ecwid.consul.v1.acl.model.Acl;
@@ -7,10 +11,18 @@ import com.ecwid.consul.v1.acl.model.NewAcl;
 import com.ecwid.consul.v1.acl.model.UpdateAcl;
 import com.ecwid.consul.v1.agent.AgentClient;
 import com.ecwid.consul.v1.agent.AgentConsulClient;
-import com.ecwid.consul.v1.agent.model.*;
+import com.ecwid.consul.v1.agent.model.Member;
+import com.ecwid.consul.v1.agent.model.NewCheck;
+import com.ecwid.consul.v1.agent.model.NewService;
+import com.ecwid.consul.v1.agent.model.Self;
+import com.ecwid.consul.v1.agent.model.Service;
 import com.ecwid.consul.v1.catalog.CatalogClient;
 import com.ecwid.consul.v1.catalog.CatalogConsulClient;
-import com.ecwid.consul.v1.catalog.model.*;
+import com.ecwid.consul.v1.catalog.model.CatalogDeregistration;
+import com.ecwid.consul.v1.catalog.model.CatalogNode;
+import com.ecwid.consul.v1.catalog.model.CatalogRegistration;
+import com.ecwid.consul.v1.catalog.model.CatalogService;
+import com.ecwid.consul.v1.catalog.model.Node;
 import com.ecwid.consul.v1.event.EventClient;
 import com.ecwid.consul.v1.event.EventConsulClient;
 import com.ecwid.consul.v1.event.model.Event;
@@ -31,503 +43,548 @@ import com.ecwid.consul.v1.session.model.Session;
 import com.ecwid.consul.v1.status.StatusClient;
 import com.ecwid.consul.v1.status.StatusConsulClient;
 
-import java.util.List;
-import java.util.Map;
-
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
-public final class ConsulClient implements AclClient, AgentClient, CatalogClient, EventClient, HealthClient, KeyValueClient, SessionClient, StatusClient {
-
-	private final AclClient aclClient;
-	private final AgentClient agentClient;
-	private final CatalogClient catalogClient;
-	private final EventClient eventClient;
-	private final HealthClient healthClient;
-	private final KeyValueClient keyValueClient;
-	private final SessionClient sessionClient;
-	private final StatusClient statusClient;
-
-	public ConsulClient(ConsulRawClient rawClient) {
-		aclClient = new AclConsulClient(rawClient);
-		agentClient = new AgentConsulClient(rawClient);
-		catalogClient = new CatalogConsulClient(rawClient);
-		eventClient = new EventConsulClient(rawClient);
-		healthClient = new HealthConsulClient(rawClient);
-		keyValueClient = new KeyValueConsulClient(rawClient);
-		sessionClient = new SessionConsulClient(rawClient);
-		statusClient = new StatusConsulClient(rawClient);
-	}
-
-	/**
-	 * Consul client will connect to local consul agent on 'http://localhost:8500'
-	 */
-	public ConsulClient() {
-		this(new ConsulRawClient());
-	}
-
-	/**
-	 * Connect to consul agent on specific address and default port (8500)
-	 *
-	 * @param agentHost Hostname or IP address of consul agent. You can specify scheme (HTTP/HTTPS) in
-	 *                  address. If there is no scheme in address - client will use HTTP.
-	 */
-	public ConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
-	}
-
-	/**
-	 * Connect to consul agent on specific address and port
-	 *
-	 * @param agentHost Hostname or IP address of consul agent. You can specify scheme (HTTP/HTTPS) in
-	 *                  address. If there is no scheme in address - client will use HTTP.
-	 * @param agentPort Consul agent port
-	 */
-	public ConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
-	}
-
-	@Override
-	public Response<String> aclCreate(NewAcl newAcl, String token) {
-		return aclClient.aclCreate(newAcl, token);
-	}
-
-	@Override
-	public Response<Void> aclUpdate(UpdateAcl updateAcl, String token) {
-		return aclClient.aclUpdate(updateAcl, token);
-	}
-
-	@Override
-	public Response<Void> aclDestroy(String aclId, String token) {
-		return aclClient.aclDestroy(aclId, token);
-	}
-
-	@Override
-	public Response<Acl> getAcl(String id) {
-		return aclClient.getAcl(id);
-	}
-
-	@Override
-	public Response<String> aclClone(String aclId, String token) {
-		return aclClient.aclClone(aclId, token);
-	}
-
-	@Override
-	public Response<List<Acl>> getAclList(String token) {
-		return aclClient.getAclList(token);
-	}
-
-	@Override
-	public Response<Map<String, com.ecwid.consul.v1.agent.model.Check>> getAgentChecks() {
-		return agentClient.getAgentChecks();
-	}
-
-	@Override
-	public Response<Map<String, Service>> getAgentServices() {
-		return agentClient.getAgentServices();
-	}
-
-	@Override
-	public Response<List<Member>> getAgentMembers() {
-		return agentClient.getAgentMembers();
-	}
-
-	@Override
-	public Response<Self> getAgentSelf() {
-		return agentClient.getAgentSelf();
-	}
-
-	@Override
-	public Response<Void> agentJoin(String address, boolean wan) {
-		return agentClient.agentJoin(address, wan);
-	}
-
-	@Override
-	public Response<Void> agentForceLeave(String node) {
-		return agentClient.agentForceLeave(node);
-	}
-
-	@Override
-	public Response<Void> agentCheckRegister(NewCheck newCheck) {
-		return agentClient.agentCheckRegister(newCheck);
-	}
-
-	public Response<Void> agentCheckRegister(NewCheck newCheck, String token) {
-		return agentClient.agentCheckRegister(newCheck, token);
-	}
-
-	@Override
-	public Response<Void> agentCheckDeregister(String checkId) {
-		return agentClient.agentCheckDeregister(checkId);
-	}
-
-	@Override
-	public Response<Void> agentCheckPass(String checkId) {
-		return agentClient.agentCheckPass(checkId);
-	}
-
-	@Override
-	public Response<Void> agentCheckPass(String checkId, String note) {
-		return agentClient.agentCheckPass(checkId, note);
-	}
-
-	@Override
-	public Response<Void> agentCheckWarn(String checkId) {
-		return agentClient.agentCheckWarn(checkId);
-	}
-
-	@Override
-	public Response<Void> agentCheckWarn(String checkId, String note) {
-		return agentClient.agentCheckWarn(checkId, note);
-	}
-
-	@Override
-	public Response<Void> agentCheckFail(String checkId) {
-		return agentClient.agentCheckFail(checkId);
-	}
-
-	@Override
-	public Response<Void> agentCheckFail(String checkId, String note) {
-		return agentClient.agentCheckFail(checkId, note);
-	}
-
-	@Override
-	public Response<Void> agentServiceRegister(NewService newService) {
-		return agentClient.agentServiceRegister(newService);
-	}
-
-	@Override
-	public Response<Void> agentServiceRegister(NewService newService, String token) {
-		return agentClient.agentServiceRegister(newService, token);
-	}
-
-	@Override
-	public Response<Void> agentServiceDeregister(String serviceId) {
-		return agentClient.agentServiceDeregister(serviceId);
-	}
-
-	@Override
-	public Response<Void> catalogRegister(CatalogRegistration catalogRegistration) {
-		return catalogClient.catalogRegister(catalogRegistration);
-	}
-
-	@Override
-	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration) {
-		return catalogClient.catalogDeregister(catalogDeregistration);
-	}
-
-	@Override
-	public Response<List<String>> getCatalogDatacenters() {
-		return catalogClient.getCatalogDatacenters();
-	}
-
-	@Override
-	public Response<List<Node>> getCatalogNodes(QueryParams queryParams) {
-		return catalogClient.getCatalogNodes(queryParams);
-	}
-
-	@Override
-	public Response<Map<String, List<String>>> getCatalogServices(QueryParams queryParams) {
-		return catalogClient.getCatalogServices(queryParams);
-	}
-
-	@Override
-	public Response<List<CatalogService>> getCatalogService(String serviceName, QueryParams queryParams) {
-		return catalogClient.getCatalogService(serviceName, queryParams);
-	}
-
-	@Override
-	public Response<List<CatalogService>> getCatalogService(String serviceName, String tag, QueryParams queryParams) {
-		return catalogClient.getCatalogService(serviceName, tag, queryParams);
-	}
-
-	@Override
-	public Response<CatalogNode> getCatalogNode(String nodeName, QueryParams queryParams) {
-		return catalogClient.getCatalogNode(nodeName, queryParams);
-	}
-
-	@Override
-	public Response<Event> eventFire(String event, String payload, EventParams eventParams, QueryParams queryParams) {
-		return eventClient.eventFire(event, payload, eventParams, queryParams);
-	}
-
-	@Override
-	public Response<List<Event>> eventList(QueryParams queryParams) {
-		return eventClient.eventList(queryParams);
-	}
-
-	@Override
-	public Response<List<Event>> eventList(String event, QueryParams queryParams) {
-		return eventClient.eventList(event, queryParams);
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksForNode(String nodeName, QueryParams queryParams) {
-		return healthClient.getHealthChecksForNode(nodeName, queryParams);
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksForService(String serviceName, QueryParams queryParams) {
-		return healthClient.getHealthChecksForService(serviceName, queryParams);
-	}
-
-	@Override
-	public Response<List<HealthService>> getHealthServices(String serviceName, boolean onlyPassing, QueryParams queryParams) {
-		return healthClient.getHealthServices(serviceName, onlyPassing, queryParams);
-	}
-
-	@Override
-	public Response<List<HealthService>> getHealthServices(String serviceName, String tag, boolean onlyPassing, QueryParams queryParams) {
-		return healthClient.getHealthServices(serviceName, tag, onlyPassing, queryParams);
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksState(QueryParams queryParams) {
-		return healthClient.getHealthChecksState(queryParams);
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksState(Check.CheckStatus checkStatus, QueryParams queryParams) {
-		return healthClient.getHealthChecksState(checkStatus, queryParams);
-	}
-
-	@Override
-	public Response<GetValue> getKVValue(String key) {
-		return keyValueClient.getKVValue(key);
-	}
-
-	@Override
-	public Response<GetValue> getKVValue(String key, String token) {
-		return keyValueClient.getKVValue(key, token);
-	}
-
-	@Override
-	public Response<GetValue> getKVValue(String key, QueryParams queryParams) {
-		return keyValueClient.getKVValue(key, queryParams);
-	}
-
-	@Override
-	public Response<GetValue> getKVValue(String key, String token, QueryParams queryParams) {
-		return keyValueClient.getKVValue(key, token, queryParams);
-	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key) {
-		return keyValueClient.getKVBinaryValue(key);
-	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key, String token) {
-		return keyValueClient.getKVBinaryValue(key, token);
-	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key, QueryParams queryParams) {
-		return keyValueClient.getKVBinaryValue(key, queryParams);
-	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key, String token, QueryParams queryParams) {
-		return keyValueClient.getKVBinaryValue(key, token, queryParams);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix) {
-		return keyValueClient.getKVValues(keyPrefix);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix, String token) {
-		return keyValueClient.getKVValues(keyPrefix, token);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix, QueryParams queryParams) {
-		return keyValueClient.getKVValues(keyPrefix, queryParams);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix, String token, QueryParams queryParams) {
-		return keyValueClient.getKVValues(keyPrefix, token, queryParams);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix) {
-		return keyValueClient.getKVBinaryValues(keyPrefix);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token) {
-		return keyValueClient.getKVBinaryValues(keyPrefix, token);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, QueryParams queryParams) {
-		return keyValueClient.getKVBinaryValues(keyPrefix, queryParams);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token, QueryParams queryParams) {
-		return keyValueClient.getKVBinaryValues(keyPrefix, token, queryParams);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix) {
-		return keyValueClient.getKVKeysOnly(keyPrefix);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token) {
-		return keyValueClient.getKVKeysOnly(keyPrefix, separator, token);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix, QueryParams queryParams) {
-		return keyValueClient.getKVKeysOnly(keyPrefix, queryParams);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token, QueryParams queryParams) {
-		return keyValueClient.getKVKeysOnly(keyPrefix, separator, token, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value) {
-		return keyValueClient.setKVValue(key, value);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, PutParams putParams) {
-		return keyValueClient.setKVValue(key, value, putParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams) {
-		return keyValueClient.setKVValue(key, value, token, putParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, QueryParams queryParams) {
-		return keyValueClient.setKVValue(key, value, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, PutParams putParams, QueryParams queryParams) {
-		return keyValueClient.setKVValue(key, value, putParams, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams, QueryParams queryParams) {
-		return keyValueClient.setKVValue(key, value, token, putParams, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value) {
-		return keyValueClient.setKVBinaryValue(key, value);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams) {
-		return keyValueClient.setKVBinaryValue(key, value, putParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams) {
-		return keyValueClient.setKVBinaryValue(key, value, token, putParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, QueryParams queryParams) {
-		return keyValueClient.setKVBinaryValue(key, value, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams, QueryParams queryParams) {
-		return keyValueClient.setKVBinaryValue(key, value, putParams, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams, QueryParams queryParams) {
-		return keyValueClient.setKVBinaryValue(key, value, token, putParams, queryParams);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key) {
-		return keyValueClient.deleteKVValue(key);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key, String token) {
-		return keyValueClient.deleteKVValue(key, token);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key, QueryParams queryParams) {
-		return keyValueClient.deleteKVValue(key, queryParams);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key, String token, QueryParams queryParams) {
-		return keyValueClient.deleteKVValue(key, token, queryParams);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key) {
-		return keyValueClient.deleteKVValues(key);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key, String token) {
-		return keyValueClient.deleteKVValues(key, token);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key, QueryParams queryParams) {
-		return keyValueClient.deleteKVValues(key, queryParams);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key, String token, QueryParams queryParams) {
-		return keyValueClient.deleteKVValues(key, token, queryParams);
-	}
-
-	@Override
-	public Response<String> sessionCreate(NewSession newSession, QueryParams queryParams) {
-		return sessionClient.sessionCreate(newSession, queryParams);
-	}
-
-	@Override
-	public Response<Void> sessionDestroy(String session, QueryParams queryParams) {
-		return sessionClient.sessionDestroy(session, queryParams);
-	}
-
-	@Override
-	public Response<Session> getSessionInfo(String session, QueryParams queryParams) {
-		return sessionClient.getSessionInfo(session, queryParams);
-	}
-
-	@Override
-	public Response<List<Session>> getSessionNode(String node, QueryParams queryParams) {
-		return sessionClient.getSessionNode(node, queryParams);
-	}
-
-	@Override
-	public Response<List<Session>> getSessionList(QueryParams queryParams) {
-		return sessionClient.getSessionList(queryParams);
-	}
-
-	@Override
-	public Response<Session> renewSession(String session, QueryParams queryParams) {
-		return sessionClient.renewSession(session, queryParams);
-	}
-
-	@Override
-	public Response<String> getStatusLeader() {
-		return statusClient.getStatusLeader();
-	}
-
-	@Override
-	public Response<List<String>> getStatusPeers() {
-		return statusClient.getStatusPeers();
-	}
+public final class ConsulClient
+        implements AclClient, AgentClient, CatalogClient, EventClient, HealthClient, KeyValueClient, SessionClient, StatusClient {
+
+    private final AclClient aclClient;
+    private final AgentClient agentClient;
+    private final CatalogClient catalogClient;
+    private final EventClient eventClient;
+    private final HealthClient healthClient;
+    private final KeyValueClient keyValueClient;
+    private final SessionClient sessionClient;
+    private final StatusClient statusClient;
+
+    public ConsulClient(ConsulRawClient rawClient) {
+	aclClient = new AclConsulClient(rawClient);
+	agentClient = new AgentConsulClient(rawClient);
+	catalogClient = new CatalogConsulClient(rawClient);
+	eventClient = new EventConsulClient(rawClient);
+	healthClient = new HealthConsulClient(rawClient);
+	keyValueClient = new KeyValueConsulClient(rawClient);
+	sessionClient = new SessionConsulClient(rawClient);
+	statusClient = new StatusConsulClient(rawClient);
+    }
+
+    /**
+     * Consul client will connect to local consul agent on
+     * 'http://localhost:8500'
+     */
+    public ConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    /**
+     * Consul client will connect to local consul agent on
+     * 'http://localhost:8500'
+     * 
+     * @param tlsConfig
+     *            TLS configuration
+     */
+    public ConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    /**
+     * Connect to consul agent on specific address and default port (8500)
+     *
+     * @param agentHost
+     *            Hostname or IP address of consul agent. You can specify scheme
+     *            (HTTP/HTTPS) in address. If there is no scheme in address -
+     *            client will use HTTP.
+     */
+    public ConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    /**
+     * Connect to consul agent on specific address and default port (8500)
+     *
+     * @param agentHost
+     *            Hostname or IP address of consul agent. You can specify scheme
+     *            (HTTP/HTTPS) in address. If there is no scheme in address -
+     *            client will use HTTP.
+     * @param tlsConfig
+     *            TLS configuration
+     */
+    public ConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    /**
+     * Connect to consul agent on specific address and port
+     *
+     * @param agentHost
+     *            Hostname or IP address of consul agent. You can specify scheme
+     *            (HTTP/HTTPS) in address. If there is no scheme in address -
+     *            client will use HTTP.
+     * @param agentPort
+     *            Consul agent port
+     */
+    public ConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    /**
+     * Connect to consul agent on specific address and port
+     *
+     * @param agentHost
+     *            Hostname or IP address of consul agent. You can specify scheme
+     *            (HTTP/HTTPS) in address. If there is no scheme in address -
+     *            client will use HTTP.
+     * @param agentPort
+     *            Consul agent port
+     * @param tlsConfig
+     *            TLS configuration
+     */
+    public ConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<String> aclCreate(NewAcl newAcl, String token) {
+	return aclClient.aclCreate(newAcl, token);
+    }
+
+    @Override
+    public Response<Void> aclUpdate(UpdateAcl updateAcl, String token) {
+	return aclClient.aclUpdate(updateAcl, token);
+    }
+
+    @Override
+    public Response<Void> aclDestroy(String aclId, String token) {
+	return aclClient.aclDestroy(aclId, token);
+    }
+
+    @Override
+    public Response<Acl> getAcl(String id) {
+	return aclClient.getAcl(id);
+    }
+
+    @Override
+    public Response<String> aclClone(String aclId, String token) {
+	return aclClient.aclClone(aclId, token);
+    }
+
+    @Override
+    public Response<List<Acl>> getAclList(String token) {
+	return aclClient.getAclList(token);
+    }
+
+    @Override
+    public Response<Map<String, com.ecwid.consul.v1.agent.model.Check>> getAgentChecks() {
+	return agentClient.getAgentChecks();
+    }
+
+    @Override
+    public Response<Map<String, Service>> getAgentServices() {
+	return agentClient.getAgentServices();
+    }
+
+    @Override
+    public Response<List<Member>> getAgentMembers() {
+	return agentClient.getAgentMembers();
+    }
+
+    @Override
+    public Response<Self> getAgentSelf() {
+	return agentClient.getAgentSelf();
+    }
+
+    @Override
+    public Response<Void> agentJoin(String address, boolean wan) {
+	return agentClient.agentJoin(address, wan);
+    }
+
+    @Override
+    public Response<Void> agentForceLeave(String node) {
+	return agentClient.agentForceLeave(node);
+    }
+
+    @Override
+    public Response<Void> agentCheckRegister(NewCheck newCheck) {
+	return agentClient.agentCheckRegister(newCheck);
+    }
+
+    public Response<Void> agentCheckRegister(NewCheck newCheck, String token) {
+	return agentClient.agentCheckRegister(newCheck, token);
+    }
+
+    @Override
+    public Response<Void> agentCheckDeregister(String checkId) {
+	return agentClient.agentCheckDeregister(checkId);
+    }
+
+    @Override
+    public Response<Void> agentCheckPass(String checkId) {
+	return agentClient.agentCheckPass(checkId);
+    }
+
+    @Override
+    public Response<Void> agentCheckPass(String checkId, String note) {
+	return agentClient.agentCheckPass(checkId, note);
+    }
+
+    @Override
+    public Response<Void> agentCheckWarn(String checkId) {
+	return agentClient.agentCheckWarn(checkId);
+    }
+
+    @Override
+    public Response<Void> agentCheckWarn(String checkId, String note) {
+	return agentClient.agentCheckWarn(checkId, note);
+    }
+
+    @Override
+    public Response<Void> agentCheckFail(String checkId) {
+	return agentClient.agentCheckFail(checkId);
+    }
+
+    @Override
+    public Response<Void> agentCheckFail(String checkId, String note) {
+	return agentClient.agentCheckFail(checkId, note);
+    }
+
+    @Override
+    public Response<Void> agentServiceRegister(NewService newService) {
+	return agentClient.agentServiceRegister(newService);
+    }
+
+    @Override
+    public Response<Void> agentServiceRegister(NewService newService, String token) {
+	return agentClient.agentServiceRegister(newService, token);
+    }
+
+    @Override
+    public Response<Void> agentServiceDeregister(String serviceId) {
+	return agentClient.agentServiceDeregister(serviceId);
+    }
+
+    @Override
+    public Response<Void> catalogRegister(CatalogRegistration catalogRegistration) {
+	return catalogClient.catalogRegister(catalogRegistration);
+    }
+
+    @Override
+    public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration) {
+	return catalogClient.catalogDeregister(catalogDeregistration);
+    }
+
+    @Override
+    public Response<List<String>> getCatalogDatacenters() {
+	return catalogClient.getCatalogDatacenters();
+    }
+
+    @Override
+    public Response<List<Node>> getCatalogNodes(QueryParams queryParams) {
+	return catalogClient.getCatalogNodes(queryParams);
+    }
+
+    @Override
+    public Response<Map<String, List<String>>> getCatalogServices(QueryParams queryParams) {
+	return catalogClient.getCatalogServices(queryParams);
+    }
+
+    @Override
+    public Response<List<CatalogService>> getCatalogService(String serviceName, QueryParams queryParams) {
+	return catalogClient.getCatalogService(serviceName, queryParams);
+    }
+
+    @Override
+    public Response<List<CatalogService>> getCatalogService(String serviceName, String tag, QueryParams queryParams) {
+	return catalogClient.getCatalogService(serviceName, tag, queryParams);
+    }
+
+    @Override
+    public Response<CatalogNode> getCatalogNode(String nodeName, QueryParams queryParams) {
+	return catalogClient.getCatalogNode(nodeName, queryParams);
+    }
+
+    @Override
+    public Response<Event> eventFire(String event, String payload, EventParams eventParams, QueryParams queryParams) {
+	return eventClient.eventFire(event, payload, eventParams, queryParams);
+    }
+
+    @Override
+    public Response<List<Event>> eventList(QueryParams queryParams) {
+	return eventClient.eventList(queryParams);
+    }
+
+    @Override
+    public Response<List<Event>> eventList(String event, QueryParams queryParams) {
+	return eventClient.eventList(event, queryParams);
+    }
+
+    @Override
+    public Response<List<Check>> getHealthChecksForNode(String nodeName, QueryParams queryParams) {
+	return healthClient.getHealthChecksForNode(nodeName, queryParams);
+    }
+
+    @Override
+    public Response<List<Check>> getHealthChecksForService(String serviceName, QueryParams queryParams) {
+	return healthClient.getHealthChecksForService(serviceName, queryParams);
+    }
+
+    @Override
+    public Response<List<HealthService>> getHealthServices(String serviceName, boolean onlyPassing, QueryParams queryParams) {
+	return healthClient.getHealthServices(serviceName, onlyPassing, queryParams);
+    }
+
+    @Override
+    public Response<List<HealthService>> getHealthServices(String serviceName, String tag, boolean onlyPassing, QueryParams queryParams) {
+	return healthClient.getHealthServices(serviceName, tag, onlyPassing, queryParams);
+    }
+
+    @Override
+    public Response<List<Check>> getHealthChecksState(QueryParams queryParams) {
+	return healthClient.getHealthChecksState(queryParams);
+    }
+
+    @Override
+    public Response<List<Check>> getHealthChecksState(Check.CheckStatus checkStatus, QueryParams queryParams) {
+	return healthClient.getHealthChecksState(checkStatus, queryParams);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key) {
+	return keyValueClient.getKVValue(key);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key, String token) {
+	return keyValueClient.getKVValue(key, token);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key, QueryParams queryParams) {
+	return keyValueClient.getKVValue(key, queryParams);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key, String token, QueryParams queryParams) {
+	return keyValueClient.getKVValue(key, token, queryParams);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key) {
+	return keyValueClient.getKVBinaryValue(key);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key, String token) {
+	return keyValueClient.getKVBinaryValue(key, token);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key, QueryParams queryParams) {
+	return keyValueClient.getKVBinaryValue(key, queryParams);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key, String token, QueryParams queryParams) {
+	return keyValueClient.getKVBinaryValue(key, token, queryParams);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix) {
+	return keyValueClient.getKVValues(keyPrefix);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix, String token) {
+	return keyValueClient.getKVValues(keyPrefix, token);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix, QueryParams queryParams) {
+	return keyValueClient.getKVValues(keyPrefix, queryParams);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix, String token, QueryParams queryParams) {
+	return keyValueClient.getKVValues(keyPrefix, token, queryParams);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix) {
+	return keyValueClient.getKVBinaryValues(keyPrefix);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token) {
+	return keyValueClient.getKVBinaryValues(keyPrefix, token);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, QueryParams queryParams) {
+	return keyValueClient.getKVBinaryValues(keyPrefix, queryParams);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token, QueryParams queryParams) {
+	return keyValueClient.getKVBinaryValues(keyPrefix, token, queryParams);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix) {
+	return keyValueClient.getKVKeysOnly(keyPrefix);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token) {
+	return keyValueClient.getKVKeysOnly(keyPrefix, separator, token);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix, QueryParams queryParams) {
+	return keyValueClient.getKVKeysOnly(keyPrefix, queryParams);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token, QueryParams queryParams) {
+	return keyValueClient.getKVKeysOnly(keyPrefix, separator, token, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value) {
+	return keyValueClient.setKVValue(key, value);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, PutParams putParams) {
+	return keyValueClient.setKVValue(key, value, putParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams) {
+	return keyValueClient.setKVValue(key, value, token, putParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, QueryParams queryParams) {
+	return keyValueClient.setKVValue(key, value, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, PutParams putParams, QueryParams queryParams) {
+	return keyValueClient.setKVValue(key, value, putParams, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams, QueryParams queryParams) {
+	return keyValueClient.setKVValue(key, value, token, putParams, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value) {
+	return keyValueClient.setKVBinaryValue(key, value);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams) {
+	return keyValueClient.setKVBinaryValue(key, value, putParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams) {
+	return keyValueClient.setKVBinaryValue(key, value, token, putParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, QueryParams queryParams) {
+	return keyValueClient.setKVBinaryValue(key, value, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams, QueryParams queryParams) {
+	return keyValueClient.setKVBinaryValue(key, value, putParams, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams, QueryParams queryParams) {
+	return keyValueClient.setKVBinaryValue(key, value, token, putParams, queryParams);
+    }
+
+    @Override
+    public Response<Void> deleteKVValue(String key) {
+	return keyValueClient.deleteKVValue(key);
+    }
+
+    @Override
+    public Response<Void> deleteKVValue(String key, String token) {
+	return keyValueClient.deleteKVValue(key, token);
+    }
+
+    @Override
+    public Response<Void> deleteKVValue(String key, QueryParams queryParams) {
+	return keyValueClient.deleteKVValue(key, queryParams);
+    }
+
+    @Override
+    public Response<Void> deleteKVValue(String key, String token, QueryParams queryParams) {
+	return keyValueClient.deleteKVValue(key, token, queryParams);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key) {
+	return keyValueClient.deleteKVValues(key);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key, String token) {
+	return keyValueClient.deleteKVValues(key, token);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key, QueryParams queryParams) {
+	return keyValueClient.deleteKVValues(key, queryParams);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key, String token, QueryParams queryParams) {
+	return keyValueClient.deleteKVValues(key, token, queryParams);
+    }
+
+    @Override
+    public Response<String> sessionCreate(NewSession newSession, QueryParams queryParams) {
+	return sessionClient.sessionCreate(newSession, queryParams);
+    }
+
+    @Override
+    public Response<Void> sessionDestroy(String session, QueryParams queryParams) {
+	return sessionClient.sessionDestroy(session, queryParams);
+    }
+
+    @Override
+    public Response<Session> getSessionInfo(String session, QueryParams queryParams) {
+	return sessionClient.getSessionInfo(session, queryParams);
+    }
+
+    @Override
+    public Response<List<Session>> getSessionNode(String node, QueryParams queryParams) {
+	return sessionClient.getSessionNode(node, queryParams);
+    }
+
+    @Override
+    public Response<List<Session>> getSessionList(QueryParams queryParams) {
+	return sessionClient.getSessionList(queryParams);
+    }
+
+    @Override
+    public Response<Session> renewSession(String session, QueryParams queryParams) {
+	return sessionClient.renewSession(session, queryParams);
+    }
+
+    @Override
+    public Response<String> getStatusLeader() {
+	return statusClient.getStatusLeader();
+    }
+
+    @Override
+    public Response<List<String>> getStatusPeers() {
+	return statusClient.getStatusPeers();
+    }
 }

--- a/src/main/java/com/ecwid/consul/v1/ConsulRawClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulRawClient.java
@@ -1,90 +1,105 @@
 package com.ecwid.consul.v1;
 
+import org.apache.http.client.HttpClient;
+
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.Utils;
 import com.ecwid.consul.transport.DefaultHttpTransport;
+import com.ecwid.consul.transport.DefaultHttpsTransport;
 import com.ecwid.consul.transport.HttpTransport;
 import com.ecwid.consul.transport.RawResponse;
-import org.apache.http.client.HttpClient;
+import com.ecwid.consul.transport.TLSConfig;
 
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public class ConsulRawClient {
 
-	private static final String DEFAULT_HOST = "localhost";
-	private static final int DEFAULT_PORT = 8500;
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 8500;
 
-	// one real HTTP client for all instances
-	private static final HttpTransport DEFAULT_HTTP_TRANSPORT = new DefaultHttpTransport();
+    // one real HTTP client for all instances
+    private static final HttpTransport DEFAULT_HTTP_TRANSPORT = new DefaultHttpTransport();
 
-	private final HttpTransport httpTransport;
-	private final String agentAddress;
+    private final HttpTransport httpTransport;
+    private final String agentAddress;
 
-	public ConsulRawClient() {
-		this(DEFAULT_HOST);
+    public ConsulRawClient() {
+	this(DEFAULT_HOST);
+    }
+
+    public ConsulRawClient(TLSConfig tlsConfig) {
+	this(DEFAULT_HOST, tlsConfig);
+    }
+
+    public ConsulRawClient(String agentHost) {
+	this(agentHost, DEFAULT_PORT);
+    }
+
+    public ConsulRawClient(String agentHost, TLSConfig tlsConfig) {
+	this(agentHost, DEFAULT_PORT, tlsConfig);
+    }
+
+    public ConsulRawClient(String agentHost, int agentPort) {
+	this(DEFAULT_HTTP_TRANSPORT, agentHost, agentPort);
+    }
+
+    public ConsulRawClient(HttpClient httpClient) {
+	this(DEFAULT_HOST, httpClient);
+    }
+
+    public ConsulRawClient(String agentHost, HttpClient httpClient) {
+	this(new DefaultHttpTransport(httpClient), agentHost, DEFAULT_PORT);
+    }
+
+    public ConsulRawClient(String agentHost, int agentPort, HttpClient httpClient) {
+	this(new DefaultHttpTransport(httpClient), agentHost, agentPort);
+    }
+
+    public ConsulRawClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new DefaultHttpsTransport(tlsConfig), agentHost, agentPort);
+    }
+
+    // hidden constructor, for tests
+    ConsulRawClient(HttpTransport httpTransport, String agentHost, int agentPort) {
+	this.httpTransport = httpTransport;
+
+	// check that agentHost has scheme or not
+	String agentHostLowercase = agentHost.toLowerCase();
+	if (!agentHostLowercase.startsWith("https://") && !agentHostLowercase.startsWith("http://")) {
+	    // no scheme in host, use default 'http'
+	    agentHost = "http://" + agentHost;
 	}
 
-	public ConsulRawClient(String agentHost) {
-		this(agentHost, DEFAULT_PORT);
-	}
+	this.agentAddress = agentHost + ":" + agentPort;
+    }
 
-	public ConsulRawClient(String agentHost, int agentPort) {
-		this(DEFAULT_HTTP_TRANSPORT, agentHost, agentPort);
-	}
+    public RawResponse makeGetRequest(String endpoint, UrlParameters... urlParams) {
+	String url = agentAddress + endpoint;
+	url = Utils.generateUrl(url, urlParams);
 
-	public ConsulRawClient(HttpClient httpClient) {
-		this(DEFAULT_HOST, httpClient);
-	}
+	return httpTransport.makeGetRequest(url);
+    }
 
-	public ConsulRawClient(String agentHost, HttpClient httpClient) {
-		this(new DefaultHttpTransport(httpClient), agentHost, DEFAULT_PORT);
-	}
+    public RawResponse makePutRequest(String endpoint, String content, UrlParameters... urlParams) {
+	String url = agentAddress + endpoint;
+	url = Utils.generateUrl(url, urlParams);
 
-	public ConsulRawClient(String agentHost, int agentPort, HttpClient httpClient) {
-		this(new DefaultHttpTransport(httpClient), agentHost, agentPort);
-	}
+	return httpTransport.makePutRequest(url, content);
+    }
 
-	// hidden constructor, for tests
-	ConsulRawClient(HttpTransport httpTransport, String agentHost, int agentPort) {
-		this.httpTransport = httpTransport;
+    public RawResponse makePutRequest(String endpoint, byte[] content, UrlParameters... urlParams) {
+	String url = agentAddress + endpoint;
+	url = Utils.generateUrl(url, urlParams);
 
-		// check that agentHost has scheme or not
-		String agentHostLowercase = agentHost.toLowerCase();
-		if (!agentHostLowercase.startsWith("https://") && !agentHostLowercase.startsWith("http://")) {
-			// no scheme in host, use default 'http'
-			agentHost = "http://" + agentHost;
-		}
+	return httpTransport.makePutRequest(url, content);
+    }
 
-		this.agentAddress = agentHost + ":" + agentPort;
-	}
+    public RawResponse makeDeleteRequest(String endpoint, UrlParameters... urlParams) {
+	String url = agentAddress + endpoint;
+	url = Utils.generateUrl(url, urlParams);
 
-	public RawResponse makeGetRequest(String endpoint, UrlParameters... urlParams) {
-		String url = agentAddress + endpoint;
-		url = Utils.generateUrl(url, urlParams);
-
-		return httpTransport.makeGetRequest(url);
-	}
-
-	public RawResponse makePutRequest(String endpoint, String content, UrlParameters... urlParams) {
-		String url = agentAddress + endpoint;
-		url = Utils.generateUrl(url, urlParams);
-
-		return httpTransport.makePutRequest(url, content);
-	}
-
-	public RawResponse makePutRequest(String endpoint, byte[] content, UrlParameters... urlParams) {
-		String url = agentAddress + endpoint;
-		url = Utils.generateUrl(url, urlParams);
-
-		return httpTransport.makePutRequest(url, content);
-	}
-
-	public RawResponse makeDeleteRequest(String endpoint, UrlParameters... urlParams) {
-		String url = agentAddress + endpoint;
-		url = Utils.generateUrl(url, urlParams);
-
-		return httpTransport.makeDeleteRequest(url);
-	}
+	return httpTransport.makeDeleteRequest(url);
+    }
 
 }

--- a/src/main/java/com/ecwid/consul/v1/acl/AclConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/acl/AclConsulClient.java
@@ -1,131 +1,143 @@
 package com.ecwid.consul.v1.acl;
 
+import java.util.List;
+import java.util.Map;
+
 import com.ecwid.consul.ConsulException;
 import com.ecwid.consul.SingleUrlParameters;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.acl.model.Acl;
 import com.ecwid.consul.v1.acl.model.NewAcl;
 import com.ecwid.consul.v1.acl.model.UpdateAcl;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.List;
-import java.util.Map;
-
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class AclConsulClient implements AclClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public AclConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public AclConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public AclConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public AclConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public AclConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public AclConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public AclConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public AclConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<String> aclCreate(NewAcl newAcl, String token) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	String json = GsonFactory.getGson().toJson(newAcl);
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/create", json, tokenParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    Map<String, String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, String>>() {
+	    }.getType());
+	    return new Response<String>(value.get("ID"), rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public AclConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<Void> aclUpdate(UpdateAcl updateAcl, String token) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	String json = GsonFactory.getGson().toJson(updateAcl);
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/update", json, tokenParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public AclConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
+    @Override
+    public Response<Void> aclDestroy(String aclId, String token) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/destroy/" + aclId, "", tokenParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public AclConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
+    @Override
+    public Response<Acl> getAcl(String id) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/acl/info/" + id);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Acl> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Acl>>() {
+	    }.getType());
+
+	    if (value.isEmpty()) {
+		return new Response<Acl>(null, rawResponse);
+	    } else if (value.size() == 1) {
+		return new Response<Acl>(value.get(0), rawResponse);
+	    } else {
+		throw new ConsulException("Strange response (list size=" + value.size() + ")");
+	    }
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<String> aclCreate(NewAcl newAcl, String token) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		String json = GsonFactory.getGson().toJson(newAcl);
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/create", json, tokenParams);
+    @Override
+    public Response<String> aclClone(String aclId, String token) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/clone/" + aclId, "", tokenParams);
 
-		if (rawResponse.getStatusCode() == 200) {
-			Map<String, String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, String>>() {
-			}.getType());
-			return new Response<String>(value.get("ID"), rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    Map<String, String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, String>>() {
+	    }.getType());
+	    return new Response<String>(value.get("ID"), rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> aclUpdate(UpdateAcl updateAcl, String token) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		String json = GsonFactory.getGson().toJson(updateAcl);
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/update", json, tokenParams);
+    @Override
+    public Response<List<Acl>> getAclList(String token) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/acl/list", tokenParams);
 
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Acl> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Acl>>() {
+	    }.getType());
+	    return new Response<List<Acl>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	@Override
-	public Response<Void> aclDestroy(String aclId, String token) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/destroy/" + aclId, "", tokenParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Acl> getAcl(String id) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/acl/info/" + id);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Acl> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Acl>>() {
-			}.getType());
-
-			if (value.isEmpty()) {
-				return new Response<Acl>(null, rawResponse);
-			} else if (value.size() == 1) {
-				return new Response<Acl>(value.get(0), rawResponse);
-			} else {
-				throw new ConsulException("Strange response (list size=" + value.size() + ")");
-			}
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-
-	@Override
-	public Response<String> aclClone(String aclId, String token) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/acl/clone/" + aclId, "", tokenParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			Map<String, String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, String>>() {
-			}.getType());
-			return new Response<String>(value.get("ID"), rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<Acl>> getAclList(String token) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/acl/list", tokenParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Acl> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Acl>>() {
-			}.getType());
-			return new Response<List<Acl>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 
 }

--- a/src/main/java/com/ecwid/consul/v1/agent/AgentConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/AgentConsulClient.java
@@ -1,224 +1,243 @@
 package com.ecwid.consul.v1.agent;
 
+import java.util.List;
+import java.util.Map;
+
 import com.ecwid.consul.SingleUrlParameters;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.Response;
-import com.ecwid.consul.v1.agent.model.*;
+import com.ecwid.consul.v1.agent.model.Check;
+import com.ecwid.consul.v1.agent.model.Member;
+import com.ecwid.consul.v1.agent.model.NewCheck;
+import com.ecwid.consul.v1.agent.model.NewService;
+import com.ecwid.consul.v1.agent.model.Self;
+import com.ecwid.consul.v1.agent.model.Service;
 import com.google.gson.reflect.TypeToken;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class AgentConsulClient implements AgentClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public AgentConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public AgentConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public AgentConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public AgentConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public AgentConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public AgentConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public AgentConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public AgentConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<Map<String, Check>> getAgentChecks() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/checks");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    Map<String, Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, Check>>() {
+	    }.getType());
+	    return new Response<Map<String, Check>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public AgentConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<Map<String, Service>> getAgentServices() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/services");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    Map<String, Service> agentServices = GsonFactory.getGson().fromJson(rawResponse.getContent(),
+	            new TypeToken<Map<String, Service>>() {
+	            }.getType());
+	    return new Response<Map<String, Service>>(agentServices, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public AgentConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
+    @Override
+    public Response<List<Member>> getAgentMembers() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/members");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Member> members = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Member>>() {
+	    }.getType());
+	    return new Response<List<Member>>(members, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public AgentConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
+    @Override
+    public Response<Self> getAgentSelf() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/self");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    Self self = GsonFactory.getGson().fromJson(rawResponse.getContent(), Self.class);
+	    return new Response<Self>(self, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Map<String, Check>> getAgentChecks() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/checks");
+    @Override
+    public Response<Void> agentJoin(String address, boolean wan) {
+	UrlParameters wanParams = wan ? new SingleUrlParameters("wan", "1") : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/join/" + address, wanParams);
 
-		if (rawResponse.getStatusCode() == 200) {
-			Map<String, Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, Check>>() {
-			}.getType());
-			return new Response<Map<String, Check>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Map<String, Service>> getAgentServices() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/services");
+    @Override
+    public Response<Void> agentForceLeave(String node) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/force-leave/" + node);
 
-		if (rawResponse.getStatusCode() == 200) {
-			Map<String, Service> agentServices = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, Service>>() {
-			}.getType());
-			return new Response<Map<String, Service>>(agentServices, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<List<Member>> getAgentMembers() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/members");
+    @Override
+    public Response<Void> agentCheckRegister(NewCheck newCheck) {
+	return agentCheckRegister(newCheck, null);
+    }
 
-		if (rawResponse.getStatusCode() == 200) {
-			List<Member> members = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Member>>() {
-			}.getType());
-			return new Response<List<Member>>(members, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+    @Override
+    public Response<Void> agentCheckRegister(NewCheck newCheck, String token) {
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+
+	String json = GsonFactory.getGson().toJson(newCheck);
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/agent/check/register", json, tokenParam);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Self> getAgentSelf() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/self");
+    @Override
+    public Response<Void> agentCheckDeregister(String checkId) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/deregister/" + checkId);
 
-		if (rawResponse.getStatusCode() == 200) {
-			Self self = GsonFactory.getGson().fromJson(rawResponse.getContent(), Self.class);
-			return new Response<Self>(self, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> agentJoin(String address, boolean wan) {
-		UrlParameters wanParams = wan ? new SingleUrlParameters("wan", "1") : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/join/" + address, wanParams);
+    @Override
+    public Response<Void> agentCheckPass(String checkId) {
+	return agentCheckPass(checkId, null);
+    }
 
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+    @Override
+    public Response<Void> agentCheckPass(String checkId, String note) {
+	UrlParameters noteParams = note != null ? new SingleUrlParameters("note", note) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/pass/" + checkId, noteParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> agentForceLeave(String node) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/force-leave/" + node);
+    @Override
+    public Response<Void> agentCheckWarn(String checkId) {
+	return agentCheckWarn(checkId, null);
+    }
 
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+    @Override
+    public Response<Void> agentCheckWarn(String checkId, String note) {
+	UrlParameters noteParams = note != null ? new SingleUrlParameters("note", note) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/warn/" + checkId, noteParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> agentCheckRegister(NewCheck newCheck) {
-		return agentCheckRegister(newCheck, null);
+    @Override
+    public Response<Void> agentCheckFail(String checkId) {
+	return agentCheckFail(checkId, null);
+    }
+
+    @Override
+    public Response<Void> agentCheckFail(String checkId, String note) {
+	UrlParameters noteParams = note != null ? new SingleUrlParameters("note", note) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/fail/" + checkId, noteParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> agentCheckRegister(NewCheck newCheck, String token) {
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+    @Override
+    public Response<Void> agentServiceRegister(NewService newService) {
+	return agentServiceRegister(newService, null);
+    }
 
-		String json = GsonFactory.getGson().toJson(newCheck);
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/agent/check/register", json, tokenParam);
+    @Override
+    public Response<Void> agentServiceRegister(NewService newService, String token) {
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
 
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	String json = GsonFactory.getGson().toJson(newService);
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/agent/service/register", json, tokenParam);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> agentCheckDeregister(String checkId) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/deregister/" + checkId);
+    @Override
+    public Response<Void> agentServiceDeregister(String serviceId) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/service/deregister/" + serviceId);
 
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	@Override
-	public Response<Void> agentCheckPass(String checkId) {
-		return agentCheckPass(checkId, null);
-	}
-
-	@Override
-	public Response<Void> agentCheckPass(String checkId, String note) {
-		UrlParameters noteParams = note != null ? new SingleUrlParameters("note", note) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/pass/" + checkId, noteParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Void> agentCheckWarn(String checkId) {
-		return agentCheckWarn(checkId, null);
-	}
-
-	@Override
-	public Response<Void> agentCheckWarn(String checkId, String note) {
-		UrlParameters noteParams = note != null ? new SingleUrlParameters("note", note) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/warn/" + checkId, noteParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Void> agentCheckFail(String checkId) {
-		return agentCheckFail(checkId, null);
-	}
-
-	@Override
-	public Response<Void> agentCheckFail(String checkId, String note) {
-		UrlParameters noteParams = note != null ? new SingleUrlParameters("note", note) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/check/fail/" + checkId, noteParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Void> agentServiceRegister(NewService newService) {
-		return agentServiceRegister(newService, null);
-	}
-
-	@Override
-	public Response<Void> agentServiceRegister(NewService newService, String token) {
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-
-		String json = GsonFactory.getGson().toJson(newService);
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/agent/service/register", json, tokenParam);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Void> agentServiceDeregister(String serviceId) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/agent/service/deregister/" + serviceId);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 
 }

--- a/src/main/java/com/ecwid/consul/v1/catalog/CatalogConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/catalog/CatalogConsulClient.java
@@ -1,11 +1,15 @@
 package com.ecwid.consul.v1.catalog;
 
+import java.util.List;
+import java.util.Map;
+
 import com.ecwid.consul.SingleUrlParameters;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.catalog.model.CatalogDeregistration;
@@ -14,126 +18,136 @@ import com.ecwid.consul.v1.catalog.model.CatalogRegistration;
 import com.ecwid.consul.v1.catalog.model.Node;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class CatalogConsulClient implements CatalogClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public CatalogConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public CatalogConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public CatalogConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public CatalogConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public CatalogConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public CatalogConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public CatalogConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public CatalogConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<Void> catalogRegister(CatalogRegistration catalogRegistration) {
+	String json = GsonFactory.getGson().toJson(catalogRegistration);
+
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/catalog/register", json);
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public CatalogConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration) {
+	String json = GsonFactory.getGson().toJson(catalogDeregistration);
+
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/catalog/deregister", json);
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public CatalogConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
+    @Override
+    public Response<List<String>> getCatalogDatacenters() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/datacenters");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<String>>() {
+	    }.getType());
+	    return new Response<List<String>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public CatalogConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
+    @Override
+    public Response<List<Node>> getCatalogNodes(QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/nodes", queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Node> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Node>>() {
+	    }.getType());
+	    return new Response<List<Node>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> catalogRegister(CatalogRegistration catalogRegistration) {
-		String json = GsonFactory.getGson().toJson(catalogRegistration);
+    @Override
+    public Response<Map<String, List<String>>> getCatalogServices(QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/services", queryParams);
 
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/catalog/register", json);
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    Map<String, List<String>> value = GsonFactory.getGson().fromJson(rawResponse.getContent(),
+	            new TypeToken<Map<String, List<String>>>() {
+	            }.getType());
+	    return new Response<Map<String, List<String>>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> catalogDeregister(CatalogDeregistration catalogDeregistration) {
-		String json = GsonFactory.getGson().toJson(catalogDeregistration);
+    @Override
+    public Response<List<com.ecwid.consul.v1.catalog.model.CatalogService>> getCatalogService(String serviceName, QueryParams queryParams) {
+	return getCatalogService(serviceName, null, queryParams);
+    }
 
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/catalog/deregister", json);
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+    @Override
+    public Response<List<com.ecwid.consul.v1.catalog.model.CatalogService>> getCatalogService(String serviceName, String tag,
+            QueryParams queryParams) {
+	UrlParameters tagParam = tag != null ? new SingleUrlParameters("tag", tag) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/service/" + serviceName, tagParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<com.ecwid.consul.v1.catalog.model.CatalogService> value = GsonFactory.getGson().fromJson(rawResponse.getContent(),
+	            new TypeToken<List<com.ecwid.consul.v1.catalog.model.CatalogService>>() {
+	            }.getType());
+	    return new Response<List<com.ecwid.consul.v1.catalog.model.CatalogService>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<List<String>> getCatalogDatacenters() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/datacenters");
+    @Override
+    public Response<CatalogNode> getCatalogNode(String nodeName, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/node/" + nodeName, queryParams);
 
-		if (rawResponse.getStatusCode() == 200) {
-			List<String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<String>>() {
-			}.getType());
-			return new Response<List<String>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    CatalogNode catalogNode = GsonFactory.getGson().fromJson(rawResponse.getContent(), CatalogNode.class);
+	    return new Response<CatalogNode>(catalogNode, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	@Override
-	public Response<List<Node>> getCatalogNodes(QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/nodes", queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Node> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Node>>() {
-			}.getType());
-			return new Response<List<Node>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Map<String, List<String>>> getCatalogServices(QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/services", queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			Map<String, List<String>> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, List<String>>>() {
-			}.getType());
-			return new Response<Map<String, List<String>>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<com.ecwid.consul.v1.catalog.model.CatalogService>> getCatalogService(String serviceName, QueryParams queryParams) {
-		return getCatalogService(serviceName, null, queryParams);
-	}
-
-	@Override
-	public Response<List<com.ecwid.consul.v1.catalog.model.CatalogService>> getCatalogService(String serviceName, String tag, QueryParams queryParams) {
-		UrlParameters tagParam = tag != null ? new SingleUrlParameters("tag", tag) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/service/" + serviceName, tagParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<com.ecwid.consul.v1.catalog.model.CatalogService> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<com.ecwid.consul.v1.catalog.model.CatalogService>>() {
-			}.getType());
-			return new Response<List<com.ecwid.consul.v1.catalog.model.CatalogService>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<CatalogNode> getCatalogNode(String nodeName, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/catalog/node/" + nodeName, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			CatalogNode catalogNode = GsonFactory.getGson().fromJson(rawResponse.getContent(), CatalogNode.class);
-			return new Response<CatalogNode>(catalogNode, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 
 }

--- a/src/main/java/com/ecwid/consul/v1/event/EventConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/event/EventConsulClient.java
@@ -1,70 +1,79 @@
 package com.ecwid.consul.v1.event;
 
+import java.util.List;
+
 import com.ecwid.consul.SingleUrlParameters;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.event.model.Event;
 import com.ecwid.consul.v1.event.model.EventParams;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.List;
-
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class EventConsulClient implements EventClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public EventConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public EventConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public EventConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public EventConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public EventConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public EventConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public EventConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<Event> eventFire(String event, String payload, EventParams eventParams, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/event/fire/" + event, payload, eventParams, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    Event value = GsonFactory.getGson().fromJson(rawResponse.getContent(), Event.class);
+	    return new Response<Event>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public EventConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<List<Event>> eventList(QueryParams queryParams) {
+	return eventList(null, queryParams);
+    }
+
+    @Override
+    public Response<List<Event>> eventList(String event, QueryParams queryParams) {
+	UrlParameters eventParams = event != null ? new SingleUrlParameters("name", event) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/event/list", eventParams, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Event> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Event>>() {
+	    }.getType());
+	    return new Response<List<Event>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	public EventConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
-	}
-
-	public EventConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
-	}
-
-	@Override
-	public Response<Event> eventFire(String event, String payload, EventParams eventParams, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/event/fire/" + event, payload, eventParams, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			Event value = GsonFactory.getGson().fromJson(rawResponse.getContent(), Event.class);
-			return new Response<Event>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<Event>> eventList(QueryParams queryParams) {
-		return eventList(null, queryParams);
-	}
-
-	@Override
-	public Response<List<Event>> eventList(String event, QueryParams queryParams) {
-		UrlParameters eventParams = event != null ? new SingleUrlParameters("name", event) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/event/list", eventParams, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Event> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Event>>() {
-			}.getType());
-			return new Response<List<Event>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 }

--- a/src/main/java/com/ecwid/consul/v1/health/HealthConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/health/HealthConsulClient.java
@@ -1,105 +1,121 @@
 package com.ecwid.consul.v1.health;
 
+import java.util.List;
+
 import com.ecwid.consul.SingleUrlParameters;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.health.model.Check;
 import com.google.gson.reflect.TypeToken;
-
-import java.util.List;
 
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class HealthConsulClient implements HealthClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public HealthConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public HealthConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public HealthConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public HealthConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public HealthConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public HealthConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public HealthConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public HealthConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<List<Check>> getHealthChecksForNode(String nodeName, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/node/" + nodeName, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Check>>() {
+	    }.getType());
+	    return new Response<List<Check>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public HealthConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<List<Check>> getHealthChecksForService(String serviceName, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/checks/" + serviceName, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Check>>() {
+	    }.getType());
+	    return new Response<List<Check>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public HealthConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
+    @Override
+    public Response<List<com.ecwid.consul.v1.health.model.HealthService>> getHealthServices(String serviceName, boolean onlyPassing,
+            QueryParams queryParams) {
+	return getHealthServices(serviceName, null, onlyPassing, queryParams);
+    }
+
+    @Override
+    public Response<List<com.ecwid.consul.v1.health.model.HealthService>> getHealthServices(String serviceName, String tag,
+            boolean onlyPassing, QueryParams queryParams) {
+	UrlParameters tagParams = tag != null ? new SingleUrlParameters("tag", tag) : null;
+	UrlParameters passingParams = onlyPassing ? new SingleUrlParameters("passing") : null;
+
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/service/" + serviceName, tagParams, passingParams, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<com.ecwid.consul.v1.health.model.HealthService> value = GsonFactory.getGson().fromJson(rawResponse.getContent(),
+	            new TypeToken<List<com.ecwid.consul.v1.health.model.HealthService>>() {
+	            }.getType());
+	    return new Response<List<com.ecwid.consul.v1.health.model.HealthService>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public HealthConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
+    @Override
+    public Response<List<Check>> getHealthChecksState(QueryParams queryParams) {
+	return getHealthChecksState(null, queryParams);
+    }
+
+    @Override
+    public Response<List<Check>> getHealthChecksState(Check.CheckStatus checkStatus, QueryParams queryParams) {
+	String status = checkStatus == null ? "ANY" : checkStatus.name().toLowerCase();
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/state/" + status, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Check>>() {
+	    }.getType());
+	    return new Response<List<Check>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksForNode(String nodeName, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/node/" + nodeName, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Check>>() {
-			}.getType());
-			return new Response<List<Check>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksForService(String serviceName, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/checks/" + serviceName, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Check>>() {
-			}.getType());
-			return new Response<List<Check>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<com.ecwid.consul.v1.health.model.HealthService>> getHealthServices(String serviceName, boolean onlyPassing, QueryParams queryParams) {
-		return getHealthServices(serviceName, null, onlyPassing, queryParams);
-	}
-
-	@Override
-	public Response<List<com.ecwid.consul.v1.health.model.HealthService>> getHealthServices(String serviceName, String tag, boolean onlyPassing, QueryParams queryParams) {
-		UrlParameters tagParams = tag != null ? new SingleUrlParameters("tag", tag) : null;
-		UrlParameters passingParams = onlyPassing ? new SingleUrlParameters("passing") : null;
-
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/service/" + serviceName, tagParams, passingParams, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<com.ecwid.consul.v1.health.model.HealthService> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<com.ecwid.consul.v1.health.model.HealthService>>() {
-			}.getType());
-			return new Response<List<com.ecwid.consul.v1.health.model.HealthService>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksState(QueryParams queryParams) {
-		return getHealthChecksState(null, queryParams);
-	}
-
-	@Override
-	public Response<List<Check>> getHealthChecksState(Check.CheckStatus checkStatus, QueryParams queryParams) {
-		String status = checkStatus == null ? "ANY" : checkStatus.name().toLowerCase();
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/health/state/" + status, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Check> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Check>>() {
-			}.getType());
-			return new Response<List<Check>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 
 }

--- a/src/main/java/com/ecwid/consul/v1/kv/KeyValueConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/kv/KeyValueConsulClient.java
@@ -1,343 +1,358 @@
 package com.ecwid.consul.v1.kv;
 
+import java.util.List;
+
 import com.ecwid.consul.ConsulException;
 import com.ecwid.consul.SingleUrlParameters;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.kv.model.GetBinaryValue;
 import com.ecwid.consul.v1.kv.model.GetValue;
 import com.ecwid.consul.v1.kv.model.PutParams;
-import com.ecwid.consul.v1.Response;
 import com.google.gson.reflect.TypeToken;
-
-import java.util.List;
 
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class KeyValueConsulClient implements KeyValueClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public KeyValueConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public KeyValueConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public KeyValueConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public KeyValueConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public KeyValueConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public KeyValueConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public KeyValueConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public KeyValueConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key) {
+	return getKVValue(key, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key, String token) {
+	return getKVValue(key, token, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key, QueryParams queryParams) {
+	return getKVValue(key, null, queryParams);
+    }
+
+    @Override
+    public Response<GetValue> getKVValue(String key, String token, QueryParams queryParams) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + key, tokenParams, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<GetValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetValue>>() {
+	    }.getType());
+
+	    if (value.size() == 0) {
+		return new Response<GetValue>(null, rawResponse);
+	    } else if (value.size() == 1) {
+		return new Response<GetValue>(value.get(0), rawResponse);
+	    } else {
+		throw new ConsulException("Strange response (list size=" + value.size() + ")");
+	    }
+	} else if (rawResponse.getStatusCode() == 404) {
+	    return new Response<GetValue>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public KeyValueConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key) {
+	return getKVBinaryValue(key, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key, String token) {
+	return getKVBinaryValue(key, token, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key, QueryParams queryParams) {
+	return getKVBinaryValue(key, null, queryParams);
+    }
+
+    @Override
+    public Response<GetBinaryValue> getKVBinaryValue(String key, String token, QueryParams queryParams) {
+	UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + key, tokenParams, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<GetBinaryValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetBinaryValue>>() {
+	    }.getType());
+
+	    if (value.size() == 0) {
+		return new Response<GetBinaryValue>(null, rawResponse);
+	    } else if (value.size() == 1) {
+		return new Response<GetBinaryValue>(value.get(0), rawResponse);
+	    } else {
+		throw new ConsulException("Strange response (list size=" + value.size() + ")");
+	    }
+	} else if (rawResponse.getStatusCode() == 404) {
+	    return new Response<GetBinaryValue>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public KeyValueConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix) {
+	return getKVValues(keyPrefix, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix, String token) {
+	return getKVValues(keyPrefix, token, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix, QueryParams queryParams) {
+	return getKVValues(keyPrefix, null, queryParams);
+    }
+
+    @Override
+    public Response<List<GetValue>> getKVValues(String keyPrefix, String token, QueryParams queryParams) {
+	UrlParameters recurseParam = new SingleUrlParameters("recurse");
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + keyPrefix, recurseParam, tokenParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<GetValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetValue>>() {
+	    }.getType());
+	    return new Response<List<GetValue>>(value, rawResponse);
+	} else if (rawResponse.getStatusCode() == 404) {
+	    return new Response<List<GetValue>>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public KeyValueConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix) {
+	return getKVBinaryValues(keyPrefix, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token) {
+	return getKVBinaryValues(keyPrefix, token, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, QueryParams queryParams) {
+	return getKVBinaryValues(keyPrefix, null, queryParams);
+    }
+
+    @Override
+    public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token, QueryParams queryParams) {
+	UrlParameters recurseParam = new SingleUrlParameters("recurse");
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + keyPrefix, recurseParam, tokenParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<GetBinaryValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetBinaryValue>>() {
+	    }.getType());
+	    return new Response<List<GetBinaryValue>>(value, rawResponse);
+	} else if (rawResponse.getStatusCode() == 404) {
+	    return new Response<List<GetBinaryValue>>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<GetValue> getKVValue(String key) {
-		return getKVValue(key, QueryParams.DEFAULT);
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix) {
+	return getKVKeysOnly(keyPrefix, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token) {
+	return getKVKeysOnly(keyPrefix, separator, token, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix, QueryParams queryParams) {
+	return getKVKeysOnly(keyPrefix, null, null, queryParams);
+    }
+
+    @Override
+    public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token, QueryParams queryParams) {
+	UrlParameters keysParam = new SingleUrlParameters("keys");
+	UrlParameters separatorParam = separator != null ? new SingleUrlParameters("separator", separator) : null;
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + keyPrefix, keysParam, separatorParam, tokenParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<String>>() {
+	    }.getType());
+	    return new Response<List<String>>(value, rawResponse);
+	} else if (rawResponse.getStatusCode() == 404) {
+	    return new Response<List<String>>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<GetValue> getKVValue(String key, String token) {
-		return getKVValue(key, token, QueryParams.DEFAULT);
+    @Override
+    public Response<Boolean> setKVValue(String key, String value) {
+	return setKVValue(key, value, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, PutParams putParams) {
+	return setKVValue(key, value, putParams, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams) {
+	return setKVValue(key, value, token, putParams, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, QueryParams queryParams) {
+	return setKVValue(key, value, null, null, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, PutParams putParams, QueryParams queryParams) {
+	return setKVValue(key, value, null, putParams, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams, QueryParams queryParams) {
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/kv/" + key, value, putParams, tokenParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    boolean result = GsonFactory.getGson().fromJson(rawResponse.getContent(), boolean.class);
+	    return new Response<Boolean>(result, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<GetValue> getKVValue(String key, QueryParams queryParams) {
-		return getKVValue(key, null, queryParams);
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value) {
+	return setKVBinaryValue(key, value, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams) {
+	return setKVBinaryValue(key, value, putParams, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams) {
+	return setKVBinaryValue(key, value, token, putParams, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, QueryParams queryParams) {
+	return setKVBinaryValue(key, value, null, null, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams, QueryParams queryParams) {
+	return setKVBinaryValue(key, value, null, putParams, queryParams);
+    }
+
+    @Override
+    public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams, QueryParams queryParams) {
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/kv/" + key, value, putParams, tokenParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    boolean result = GsonFactory.getGson().fromJson(rawResponse.getContent(), boolean.class);
+	    return new Response<Boolean>(result, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<GetValue> getKVValue(String key, String token, QueryParams queryParams) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + key, tokenParams, queryParams);
+    @Override
+    public Response<Void> deleteKVValue(String key) {
+	return deleteKVValue(key, QueryParams.DEFAULT);
+    }
 
-		if (rawResponse.getStatusCode() == 200) {
-			List<GetValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetValue>>(){}.getType());
+    @Override
+    public Response<Void> deleteKVValue(String key, String token) {
+	return deleteKVValue(key, token, QueryParams.DEFAULT);
+    }
 
-			if (value.size() == 0) {
-				return new Response<GetValue>(null, rawResponse);
-			} else if (value.size() == 1) {
-				return new Response<GetValue>(value.get(0), rawResponse);
-			} else {
-				throw new ConsulException("Strange response (list size=" + value.size() + ")");
-			}
-		} else if (rawResponse.getStatusCode() == 404) {
-			return new Response<GetValue>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+    @Override
+    public Response<Void> deleteKVValue(String key, QueryParams queryParams) {
+	return deleteKVValue(key, null, queryParams);
+    }
+
+    @Override
+    public Response<Void> deleteKVValue(String key, String token, QueryParams queryParams) {
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeDeleteRequest("/v1/kv/" + key, tokenParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key) {
-		return getKVBinaryValue(key, QueryParams.DEFAULT);
+    @Override
+    public Response<Void> deleteKVValues(String key) {
+	return deleteKVValues(key, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key, String token) {
+	return deleteKVValues(key, token, QueryParams.DEFAULT);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key, QueryParams queryParams) {
+	return deleteKVValues(key, null, queryParams);
+    }
+
+    @Override
+    public Response<Void> deleteKVValues(String key, String token, QueryParams queryParams) {
+	UrlParameters recurseParam = new SingleUrlParameters("recurse");
+	UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
+	RawResponse rawResponse = rawClient.makeDeleteRequest("/v1/kv/" + key, tokenParam, recurseParam, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key, String token) {
-		return getKVBinaryValue(key, token, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key, QueryParams queryParams) {
-		return getKVBinaryValue(key, null, queryParams);
-	}
-
-	@Override
-	public Response<GetBinaryValue> getKVBinaryValue(String key, String token, QueryParams queryParams) {
-		UrlParameters tokenParams = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + key, tokenParams, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<GetBinaryValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetBinaryValue>>(){}.getType());
-
-			if (value.size() == 0) {
-				return new Response<GetBinaryValue>(null, rawResponse);
-			} else if (value.size() == 1) {
-				return new Response<GetBinaryValue>(value.get(0), rawResponse);
-			} else {
-				throw new ConsulException("Strange response (list size=" + value.size() + ")");
-			}
-		} else if (rawResponse.getStatusCode() == 404) {
-			return new Response<GetBinaryValue>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix) {
-		return getKVValues(keyPrefix, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix, String token) {
-		return getKVValues(keyPrefix, token, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix, QueryParams queryParams) {
-		return getKVValues(keyPrefix, null, queryParams);
-	}
-
-	@Override
-	public Response<List<GetValue>> getKVValues(String keyPrefix, String token, QueryParams queryParams) {
-		UrlParameters recurseParam = new SingleUrlParameters("recurse");
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + keyPrefix, recurseParam, tokenParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<GetValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetValue>>() {
-			}.getType());
-			return new Response<List<GetValue>>(value, rawResponse);
-		} else if (rawResponse.getStatusCode() == 404) {
-			return new Response<List<GetValue>>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix) {
-		return getKVBinaryValues(keyPrefix, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token) {
-		return getKVBinaryValues(keyPrefix, token, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, QueryParams queryParams) {
-		return getKVBinaryValues(keyPrefix, null, queryParams);
-	}
-
-	@Override
-	public Response<List<GetBinaryValue>> getKVBinaryValues(String keyPrefix, String token, QueryParams queryParams) {
-		UrlParameters recurseParam = new SingleUrlParameters("recurse");
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + keyPrefix, recurseParam, tokenParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<GetBinaryValue> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<GetBinaryValue>>() {
-			}.getType());
-			return new Response<List<GetBinaryValue>>(value, rawResponse);
-		} else if (rawResponse.getStatusCode() == 404) {
-			return new Response<List<GetBinaryValue>>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix) {
-		return getKVKeysOnly(keyPrefix, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token) {
-		return getKVKeysOnly(keyPrefix, separator, token, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix, QueryParams queryParams) {
-		return getKVKeysOnly(keyPrefix, null, null, queryParams);
-	}
-
-	@Override
-	public Response<List<String>> getKVKeysOnly(String keyPrefix, String separator, String token, QueryParams queryParams) {
-		UrlParameters keysParam = new SingleUrlParameters("keys");
-		UrlParameters separatorParam = separator != null ? new SingleUrlParameters("separator", separator) : null;
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/kv/" + keyPrefix, keysParam, separatorParam, tokenParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<String>>() {
-			}.getType());
-			return new Response<List<String>>(value, rawResponse);
-		} else if (rawResponse.getStatusCode() == 404) {
-			return new Response<List<String>>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value) {
-		return setKVValue(key, value, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, PutParams putParams) {
-		return setKVValue(key, value, putParams, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams) {
-		return setKVValue(key, value, token, putParams, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, QueryParams queryParams) {
-		return setKVValue(key, value, null, null, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, PutParams putParams, QueryParams queryParams) {
-		return setKVValue(key, value, null, putParams, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVValue(String key, String value, String token, PutParams putParams, QueryParams queryParams) {
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/kv/" + key, value, putParams, tokenParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			boolean result = GsonFactory.getGson().fromJson(rawResponse.getContent(), boolean.class);
-			return new Response<Boolean>(result, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value) {
-		return setKVBinaryValue(key, value, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams) {
-		return setKVBinaryValue(key, value, putParams, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams) {
-		return setKVBinaryValue(key, value, token, putParams, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, QueryParams queryParams) {
-		return setKVBinaryValue(key, value, null, null, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, PutParams putParams, QueryParams queryParams) {
-		return setKVBinaryValue(key, value, null, putParams, queryParams);
-	}
-
-	@Override
-	public Response<Boolean> setKVBinaryValue(String key, byte[] value, String token, PutParams putParams, QueryParams queryParams) {
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/kv/" + key, value, putParams, tokenParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			boolean result = GsonFactory.getGson().fromJson(rawResponse.getContent(), boolean.class);
-			return new Response<Boolean>(result, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key) {
-		return deleteKVValue(key, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key, String token) {
-		return deleteKVValue(key, token, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key, QueryParams queryParams) {
-		return deleteKVValue(key, null, queryParams);
-	}
-
-	@Override
-	public Response<Void> deleteKVValue(String key, String token, QueryParams queryParams) {
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeDeleteRequest("/v1/kv/" + key, tokenParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key) {
-		return deleteKVValues(key, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key, String token) {
-		return deleteKVValues(key, token, QueryParams.DEFAULT);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key, QueryParams queryParams) {
-		return deleteKVValues(key, null, queryParams);
-	}
-
-	@Override
-	public Response<Void> deleteKVValues(String key, String token, QueryParams queryParams) {
-		UrlParameters recurseParam = new SingleUrlParameters("recurse");
-		UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
-		RawResponse rawResponse = rawClient.makeDeleteRequest("/v1/kv/" + key, tokenParam, recurseParam, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 }

--- a/src/main/java/com/ecwid/consul/v1/session/SessionConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/session/SessionConsulClient.java
@@ -1,127 +1,140 @@
 package com.ecwid.consul.v1.session;
 
+import java.util.List;
+import java.util.Map;
+
 import com.ecwid.consul.ConsulException;
 import com.ecwid.consul.json.GsonFactory;
-import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.session.model.NewSession;
 import com.ecwid.consul.v1.session.model.Session;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.List;
-import java.util.Map;
-
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class SessionConsulClient implements SessionClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public SessionConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public SessionConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public SessionConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public SessionConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public SessionConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public SessionConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public SessionConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public SessionConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<String> sessionCreate(NewSession newSession, QueryParams queryParams) {
+	String json = GsonFactory.getGson().toJson(newSession);
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/session/create", json, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    Map<String, String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, String>>() {
+	    }.getType());
+	    return new Response<String>(value.get("ID"), rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public SessionConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<Void> sessionDestroy(String session, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/session/destroy/" + session, "", queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public SessionConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
+    @Override
+    public Response<Session> getSessionInfo(String session, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/session/info/" + session, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
+	    }.getType());
+
+	    if (value.isEmpty()) {
+		return new Response<Session>(null, rawResponse);
+	    } else if (value.size() == 1) {
+		return new Response<Session>(value.get(0), rawResponse);
+	    } else {
+		throw new ConsulException("Strange response (list size=" + value.size() + ")");
+	    }
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public SessionConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
+    @Override
+    public Response<List<Session>> getSessionNode(String node, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/session/node/" + node, queryParams);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
+	    }.getType());
+	    return new Response<List<Session>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<String> sessionCreate(NewSession newSession, QueryParams queryParams) {
-		String json = GsonFactory.getGson().toJson(newSession);
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/session/create", json, queryParams);
+    @Override
+    public Response<List<Session>> getSessionList(QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/session/list", queryParams);
 
-		if (rawResponse.getStatusCode() == 200) {
-			Map<String, String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<Map<String, String>>() {
-			}.getType());
-			return new Response<String>(value.get("ID"), rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
+	    }.getType());
+	    return new Response<List<Session>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	@Override
-	public Response<Void> sessionDestroy(String session, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/session/destroy/" + session, "", queryParams);
+    public Response<Session> renewSession(String session, QueryParams queryParams) {
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/session/renew/" + session, "", queryParams);
 
-		if (rawResponse.getStatusCode() == 200) {
-			return new Response<Void>(null, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
+	if (rawResponse.getStatusCode() == 200) {
+	    List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
+	    }.getType());
+
+	    if (value.size() == 1) {
+		return new Response<Session>(value.get(0), rawResponse);
+	    } else {
+		throw new ConsulException("Strange response (list size=" + value.size() + ")");
+	    }
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	@Override
-	public Response<Session> getSessionInfo(String session, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/session/info/" + session, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
-			}.getType());
-
-			if (value.isEmpty()) {
-				return new Response<Session>(null, rawResponse);
-			} else if (value.size() == 1) {
-				return new Response<Session>(value.get(0), rawResponse);
-			} else {
-				throw new ConsulException("Strange response (list size=" + value.size() + ")");
-			}
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<Session>> getSessionNode(String node, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/session/node/" + node, queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
-			}.getType());
-			return new Response<List<Session>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<Session>> getSessionList(QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/session/list", queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
-			}.getType());
-			return new Response<List<Session>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	public Response<Session> renewSession(String session, QueryParams queryParams) {
-		RawResponse rawResponse = rawClient.makePutRequest("/v1/session/renew/" + session, "", queryParams);
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<Session> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<Session>>() {
-			}.getType());
-
-			if (value.size() == 1) {
-				return new Response<Session>(value.get(0), rawResponse);
-			} else {
-				throw new ConsulException("Strange response (list size=" + value.size() + ")");
-			}
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
+    }
 }

--- a/src/main/java/com/ecwid/consul/v1/status/StatusConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/status/StatusConsulClient.java
@@ -3,6 +3,7 @@ package com.ecwid.consul.v1.status;
 import com.ecwid.consul.json.GsonFactory;
 import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulRawClient;
 import com.ecwid.consul.v1.Response;
 import com.google.gson.reflect.TypeToken;
@@ -14,48 +15,59 @@ import java.util.List;
  */
 public final class StatusConsulClient implements StatusClient {
 
-	private final ConsulRawClient rawClient;
+    private final ConsulRawClient rawClient;
 
-	public StatusConsulClient(ConsulRawClient rawClient) {
-		this.rawClient = rawClient;
+    public StatusConsulClient(ConsulRawClient rawClient) {
+	this.rawClient = rawClient;
+    }
+
+    public StatusConsulClient() {
+	this(new ConsulRawClient());
+    }
+
+    public StatusConsulClient(TLSConfig tlsConfig) {
+	this(new ConsulRawClient(tlsConfig));
+    }
+
+    public StatusConsulClient(String agentHost) {
+	this(new ConsulRawClient(agentHost));
+    }
+
+    public StatusConsulClient(String agentHost, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, tlsConfig));
+    }
+
+    public StatusConsulClient(String agentHost, int agentPort) {
+	this(new ConsulRawClient(agentHost, agentPort));
+    }
+
+    public StatusConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+	this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+    }
+
+    @Override
+    public Response<String> getStatusLeader() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/status/leader");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    String value = GsonFactory.getGson().fromJson(rawResponse.getContent(), String.class);
+	    return new Response<String>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
+    }
 
-	public StatusConsulClient() {
-		this(new ConsulRawClient());
+    @Override
+    public Response<List<String>> getStatusPeers() {
+	RawResponse rawResponse = rawClient.makeGetRequest("/v1/status/peers");
+
+	if (rawResponse.getStatusCode() == 200) {
+	    List<String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<String>>() {
+	    }.getType());
+	    return new Response<List<String>>(value, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
 	}
-
-	public StatusConsulClient(String agentHost) {
-		this(new ConsulRawClient(agentHost));
-	}
-
-	public StatusConsulClient(String agentHost, int agentPort) {
-		this(new ConsulRawClient(agentHost, agentPort));
-	}
-
-	@Override
-	public Response<String> getStatusLeader() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/status/leader");
-
-		if (rawResponse.getStatusCode() == 200) {
-			String value = GsonFactory.getGson().fromJson(rawResponse.getContent(), String.class);
-			return new Response<String>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
-	@Override
-	public Response<List<String>> getStatusPeers() {
-		RawResponse rawResponse = rawClient.makeGetRequest("/v1/status/peers");
-
-		if (rawResponse.getStatusCode() == 200) {
-			List<String> value = GsonFactory.getGson().fromJson(rawResponse.getContent(), new TypeToken<List<String>>() {
-			}.getType());
-			return new Response<List<String>>(value, rawResponse);
-		} else {
-			throw new OperationException(rawResponse);
-		}
-	}
-
+    }
 
 }


### PR DESCRIPTION
Our consul agent is configured to only accept connections using TLS and consul-api did not support this type of connection. For this reason, we made some modifications to the component could support HTTPS connections with settings parameters to certificate, keystore and password for both.
An abstract class was extracted (AbstractHttpTransport) with common methods between the existing class (DefaultHttpTransport) and the new class (DefaultHttpsTransport).
In this new class, is held the setup of httpClient with the parameters for connection using TLS.
To instace a ConsulClient on our project, now we use:
TLSConfig tlsConfig = new TLSConfig(KeyStoreInstanceType.PKCS12, "/etc/opt/consul/ssl/localhost.p12", "password",
	            "/usr/lib/jvm/jdk1.8.0_51/jre/lib/security/cacerts", "changeit", 8501);
	    client = new ConsulClient(https://localhost.consul, 8501, tlsConfig);