### PR TITLE
add maintenance endpoint to AgentClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk7
-  - openjdk6
 
 notifications:
   email:

--- a/src/main/java/com/ecwid/consul/v1/ConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulClient.java
@@ -255,6 +255,11 @@ public final class ConsulClient
 	}
 
 	@Override
+	public Response<Void> agentServiceSetMaintenance(String serviceId, boolean maintenanceEnabled) {
+		return agentClient.agentServiceSetMaintenance(serviceId, maintenanceEnabled);
+	}
+
+	@Override
 	public Response<Void> catalogRegister(CatalogRegistration catalogRegistration) {
 		return catalogClient.catalogRegister(catalogRegistration);
 	}

--- a/src/main/java/com/ecwid/consul/v1/agent/AgentClient.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/AgentClient.java
@@ -46,4 +46,6 @@ public interface AgentClient {
 	public Response<Void> agentServiceRegister(NewService newService, String token);
 
 	public Response<Void> agentServiceDeregister(String serviceId);
+
+	public Response<Void> agentServiceSetMaintenance(String serviceId, boolean maintenanceEnabled);
 }

--- a/src/main/java/com/ecwid/consul/v1/agent/AgentConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/AgentConsulClient.java
@@ -240,4 +240,15 @@ public final class AgentConsulClient implements AgentClient {
 	}
     }
 
+    @Override
+    public Response<Void> agentServiceSetMaintenance(String serviceId, boolean maintenanceEnabled) {
+	UrlParameters maintenanceParameter = new SingleUrlParameters("enable", Boolean.toString(maintenanceEnabled));
+	RawResponse rawResponse = rawClient.makePutRequest("/v1/agent/service/maintenance/" + serviceId, "", maintenanceParameter);
+
+	if (rawResponse.getStatusCode() == 200) {
+	    return new Response<Void>(null, rawResponse);
+	} else {
+	    throw new OperationException(rawResponse);
+	}
+    }
 }


### PR DESCRIPTION
We would like to use the maintenance endpoint of consul.

So here is an implementation of the endpoint:
https://www.consul.io/docs/agent/http/agent.html#agent_service_maintenance