### PR TITLE
Added TCP property to NewService.Check

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/agent/model/NewService.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/NewService.java
@@ -19,6 +19,8 @@ public class NewService {
 		private String ttl;
 		@SerializedName("HTTP")
 		private String http;
+		@SerializedName("TCP")
+		private String tcp;
         @SerializedName("Timeout")
         private String timeout;
 
@@ -54,7 +56,15 @@ public class NewService {
 			this.http = http;
 		}
 
-        public String getTimeout() {
+		public String getTcp() {
+			return tcp;
+		}
+
+		public void setTcp(String tcp) {
+			this.tcp = tcp;
+		}
+
+		public String getTimeout() {
           return timeout;
         }
 
@@ -69,6 +79,7 @@ public class NewService {
 					", interval=" + interval +
 					", ttl=" + ttl +
 					", http=" + http +
+					", tcp=" + tcp +
                     ", timeout=" + timeout +
 					'}';
 		}


### PR DESCRIPTION
I'm sorry, but I realized that I didn't add TCP property to NewService.Check class where I wanted it. The fact that there are classes with similar names like `Check` and `NewCheck`, `Service` and `NewService` is confusing. Hopefully, my original [PR](https://github.com/Ecwid/consul-api/commit/ff6318079c055708dd51a76d85d3e1fcc34b360b) is still relevant.