### PR TITLE
Changed enum values so gson deserialize them correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def doUploadArchives = project.hasProperty('sonatypeUsername') && project.hasPro
 if (doUploadArchives) {
 	group = "com.ecwid.consul"
 	archivesBaseName = "consul-api"
-	version = "1.1.9"
+	version = "1.1.10-SNAPSHOT"
 
 	signing {
 		sign configurations.archives

--- a/src/main/java/com/ecwid/consul/v1/agent/model/Check.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/Check.java
@@ -10,10 +10,14 @@ import java.util.Map;
 public class Check {
 
 	public static enum CheckStatus {
-		unknown,
-		passing,
-		warning,
-		critical
+		@SerializedName("unknown")
+		UNKNOWN,
+		@SerializedName("passing")
+		PASSING,
+		@SerializedName("warning")
+		WARNING,
+		@SerializedName("critical")
+		CRITICAL
 	}
 
 	@SerializedName("Node")

--- a/src/main/java/com/ecwid/consul/v1/agent/model/Check.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/Check.java
@@ -10,10 +10,10 @@ import java.util.Map;
 public class Check {
 
 	public static enum CheckStatus {
-		UNKNOWN,
-		PASSING,
-		WARNING,
-		CRITICAL
+		unknown,
+		passing,
+		warning,
+		critical
 	}
 
 	@SerializedName("Node")


### PR DESCRIPTION
I had problems using getAgentChecks API because the check status was always null. I discovered that gson was not serializing correctly enum values from Check.CheckStatus. The problem was that HTTP values were lowercase (.."Status":"warning"...) and enum values were uppercase.
Changing enum to lowercase worked perfectly.

