### PR TITLE
fix CheckStatus enum serialized names in the agent model and the cata…

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/agent/model/Check.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/Check.java
@@ -10,9 +10,13 @@ import java.util.Map;
 public class Check {
 
 	public static enum CheckStatus {
+		@SerializedName("unknown")
 		UNKNOWN,
+		@SerializedName("passing")
 		PASSING,
+		@SerializedName("warning")
 		WARNING,
+		@SerializedName("critical")
 		CRITICAL
 	}
 

--- a/src/main/java/com/ecwid/consul/v1/catalog/model/CatalogRegistration.java
+++ b/src/main/java/com/ecwid/consul/v1/catalog/model/CatalogRegistration.java
@@ -78,9 +78,13 @@ public class CatalogRegistration {
 	}
 
 	public static enum CheckStatus {
+		@SerializedName("unknown")
 		UNKNOWN,
+		@SerializedName("passing")
 		PASSING,
+		@SerializedName("warning")
 		WARNING,
+		@SerializedName("critical")
 		CRITICAL
 	}
 


### PR DESCRIPTION
The consul check status should use the lowercase values. the health model has already been corrected by #5 , here also need to do the same thing for agent model and catalog model. 
also see the #53. 