### PR TITLE
Add support for deregisterCriticalServiceAfter

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/agent/model/NewService.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/NewService.java
@@ -102,6 +102,9 @@ public class NewService {
 
 	@SerializedName("Check")
 	private Check check;
+	
+	@SerializedName("DeregisterCriticalServiceAfter")
+	private String deregisterCriticalServiceAfter;
 
 	public String getId() {
 		return id;
@@ -149,6 +152,14 @@ public class NewService {
 
 	public void setCheck(Check check) {
 		this.check = check;
+	}
+	
+	public String getDeregisterCriticalServiceAfter(){
+		return deregisterCriticalServiceAfter;
+	}
+	
+	public void setDeregisterCriticalServiceAfter(String deregisterCriticalServiceAfter){
+		this.deregisterCriticalServiceAfter = deregisterCriticalServiceAfter
 	}
 
 	@Override


### PR DESCRIPTION
Consul 7.0 adds support for `DeregisterCriticalServiceAfter`. Based on the Gson serialization of `NewService`, this is all that should be required. 

See https://github.com/Ecwid/consul-api/issues/64