### PR TITLE
Add support for DeregisterCriticalServiceAfter

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/agent/model/NewCheck.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/NewCheck.java
@@ -40,6 +40,9 @@ public class NewCheck {
 	@SerializedName("TTL")
 	private String ttl;
 
+	@SerializedName("DeregisterCriticalServiceAfter")
+	private String deregisterCriticalServiceAfter;
+
 	public String getId() {
 		return id;
 	}
@@ -128,6 +131,14 @@ public class NewCheck {
       this.timeout = timeout;
     }
 
+	public String getDeregisterCriticalServiceAfter() {
+		return deregisterCriticalServiceAfter;
+	}
+
+	public void setDeregisterCriticalServiceAfter(String deregisterCriticalServiceAfter) {
+		this.deregisterCriticalServiceAfter = deregisterCriticalServiceAfter;
+	}
+
 	@Override
 	public String toString() {
 		return "NewCheck{" +
@@ -142,6 +153,7 @@ public class NewCheck {
 				", interval='" + interval + '\'' +
 				", timeout='" + timeout + '\'' +
 				", ttl='" + ttl + '\'' +
+				", deregisterCriticalServiceAfter='" + deregisterCriticalServiceAfter + '\'' +
 				'}';
 	}
 }

--- a/src/main/java/com/ecwid/consul/v1/agent/model/NewService.java
+++ b/src/main/java/com/ecwid/consul/v1/agent/model/NewService.java
@@ -23,6 +23,8 @@ public class NewService {
 		private String tcp;
         @SerializedName("Timeout")
         private String timeout;
+		@SerializedName("DeregisterCriticalServiceAfter")
+		private String deregisterCriticalServiceAfter;
 
 		public String getScript() {
 			return script;
@@ -72,7 +74,15 @@ public class NewService {
           this.timeout = timeout;
         }
 
-        @Override
+		public String getDeregisterCriticalServiceAfter() {
+			return deregisterCriticalServiceAfter;
+		}
+
+		public void setDeregisterCriticalServiceAfter(String deregisterCriticalServiceAfter) {
+			this.deregisterCriticalServiceAfter = deregisterCriticalServiceAfter;
+		}
+
+		@Override
 		public String toString() {
 			return "Check{" +
 					"script='" + script + '\'' +
@@ -81,6 +91,7 @@ public class NewService {
 					", http=" + http +
 					", tcp=" + tcp +
                     ", timeout=" + timeout +
+					", deregisterCriticalServiceAfter=" + deregisterCriticalServiceAfter +
 					'}';
 		}
 	}


### PR DESCRIPTION
In Consul 0.7 onwards, checks associated with a service may contain an
optional `DeregisterCriticalServiceAfter` field. If a checks is in the
critical state for more than the value of this new field, then it is
automatically deregistered