### PR TITLE
QueryParams Builder again

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/QueryParams.java
+++ b/src/main/java/com/ecwid/consul/v1/QueryParams.java
@@ -10,6 +10,47 @@ import java.util.List;
  * @author Vasily Vasilkov (vgv@ecwid.com)
  */
 public final class QueryParams implements UrlParameters {
+	public static final class Builder {
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		private String datacenter;
+		private ConsistencyMode consistencyMode;
+		private long waitTime;
+		private long index;
+
+		private Builder() {
+			this.datacenter = null;
+			this.consistencyMode = ConsistencyMode.DEFAULT;
+			this.waitTime = -1;
+			this.index = -1;
+		}
+
+		public Builder setConsistencyMode(ConsistencyMode consistencyMode) {
+			this.consistencyMode = consistencyMode;
+			return this;
+		}
+
+		public Builder setDatacenter(String datacenter) {
+			this.datacenter = datacenter;
+			return this;
+		}
+
+		public Builder setWaitTime(long waitTime) {
+			this.waitTime = waitTime;
+			return this;
+		}
+
+		public Builder setIndex(long index) {
+			this.index = index;
+			return this;
+		}
+
+		public QueryParams build() {
+			return new QueryParams(datacenter, consistencyMode, waitTime, index);
+		}
+	}
 
 	public static final QueryParams DEFAULT = new QueryParams(ConsistencyMode.DEFAULT);
 
@@ -19,32 +60,27 @@ public final class QueryParams implements UrlParameters {
 	private final long waitTime;
 	private final long index;
 
-	public QueryParams(String datacenter) {
+	private QueryParams(String datacenter, ConsistencyMode consistencyMode, long waitTime, long index) {
 		this.datacenter = datacenter;
-		this.consistencyMode = ConsistencyMode.DEFAULT;
-		this.waitTime = -1;
-		this.index = -1;
+		this.consistencyMode = consistencyMode;
+		this.waitTime = waitTime;
+		this.index = index;
+	}
+
+	public QueryParams(String datacenter) {
+		this(datacenter, ConsistencyMode.DEFAULT, -1, -1);
 	}
 
 	public QueryParams(ConsistencyMode consistencyMode) {
-		this.datacenter = null;
-		this.consistencyMode = consistencyMode;
-		this.waitTime = -1;
-		this.index = -1;
+		this(null, consistencyMode, -1, -1);
 	}
 
 	public QueryParams(String datacenter, ConsistencyMode consistencyMode) {
-		this.datacenter = datacenter;
-		this.consistencyMode = consistencyMode;
-		this.waitTime = -1;
-		this.index = -1;
+		this(datacenter, consistencyMode, -1, -1);
 	}
 
 	public QueryParams(long waitTime, long index) {
-		this.datacenter = null;
-		this.consistencyMode = ConsistencyMode.DEFAULT;
-		this.waitTime = waitTime;
-		this.index = index;
+		this(null, ConsistencyMode.DEFAULT, waitTime, index);
 	}
 
 	public String getDatacenter() {

--- a/src/test/java/com/ecwid/consul/v1/QueryParamsTest.java
+++ b/src/test/java/com/ecwid/consul/v1/QueryParamsTest.java
@@ -1,0 +1,44 @@
+package com.ecwid.consul.v1;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static com.ecwid.consul.v1.QueryParams.Builder;
+
+public class QueryParamsTest {
+	@Test
+	public void queryParamsBuilder_ShouldReturnAllDefaults_WhenNoValuesAdded() {
+		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.DEFAULT;
+		final long EXPECTED_INDEX = -1;
+		final long EXPECTED_WAIT_TIME = -1;
+
+		Builder builder = Builder.builder();
+
+		QueryParams actual = builder.build();
+
+		assertNull(actual.getDatacenter());
+		assertEquals(actual.getConsistencyMode(), EXPECTED_MODE);
+		assertEquals(actual.getWaitTime(), EXPECTED_WAIT_TIME);
+		assertEquals(actual.getIndex(), EXPECTED_INDEX);
+	}
+
+	@Test
+	public void queryParamsBuilder_ShouldReturnQueryParams_WithCorrectValuesApplied() {
+		final String EXPECTED_DATACENTER = "testDC";
+		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.CONSISTENT;
+		final long EXPECTED_INDEX = 100;
+		final long EXPECTED_WAIT_TIME = 10000;
+
+		Builder builder = Builder.builder();
+		QueryParams actual = builder.setDatacenter(EXPECTED_DATACENTER)
+			.setConsistencyMode(EXPECTED_MODE)
+			.setWaitTime(EXPECTED_WAIT_TIME)
+			.setIndex(EXPECTED_INDEX)
+			.build();
+
+		assertEquals(actual.getDatacenter(), EXPECTED_DATACENTER);
+		assertEquals(actual.getConsistencyMode(), EXPECTED_MODE);
+		assertEquals(actual.getIndex(), EXPECTED_INDEX);
+		assertEquals(actual.getWaitTime(), EXPECTED_WAIT_TIME);
+	}
+}


### PR DESCRIPTION
Ran into a situation while working this the consul-api where (as stated in another PR) the need for both the DataCenter and blocking information to be set was required.   

Since the previous PR has not had work done on it in almost a year and noticing the significant number of files changed, we just wanted to go with a smaller PR that was targeted at just the QueryParams building aspect.   

Also adjusted the QueryParams constructors to all use the newly added private total constructor. 
