### PR TITLE
Add support for `near` queryparam #82

### DIFF
--- a/src/main/java/com/ecwid/consul/Utils.java
+++ b/src/main/java/com/ecwid/consul/Utils.java
@@ -79,4 +79,8 @@ public class Utils {
 	private static int compareLong(long x, long y) {
 		return (x < y) ? -1 : ((x == y) ? 0 : 1);
 	}
+
+	public static String toSecondsString(long waitTime) {
+		return String.valueOf(waitTime) + "s";
+	}
 }

--- a/src/main/java/com/ecwid/consul/v1/QueryParams.java
+++ b/src/main/java/com/ecwid/consul/v1/QueryParams.java
@@ -19,12 +19,14 @@ public final class QueryParams implements UrlParameters {
 		private ConsistencyMode consistencyMode;
 		private long waitTime;
 		private long index;
+		private String near;
 
 		private Builder() {
 			this.datacenter = null;
 			this.consistencyMode = ConsistencyMode.DEFAULT;
 			this.waitTime = -1;
 			this.index = -1;
+			this.near = null;
 		}
 
 		public Builder setConsistencyMode(ConsistencyMode consistencyMode) {
@@ -47,8 +49,13 @@ public final class QueryParams implements UrlParameters {
 			return this;
 		}
 
+		public Builder setNear(String near) {
+			this.near = near;
+			return this;
+		}
+
 		public QueryParams build() {
-			return new QueryParams(datacenter, consistencyMode, waitTime, index);
+			return new QueryParams(datacenter, consistencyMode, waitTime, index, near);
 		}
 	}
 
@@ -56,15 +63,20 @@ public final class QueryParams implements UrlParameters {
 
 	private final String datacenter;
 	private final ConsistencyMode consistencyMode;
-
 	private final long waitTime;
 	private final long index;
+	private final String near;
 
-	private QueryParams(String datacenter, ConsistencyMode consistencyMode, long waitTime, long index) {
+	private QueryParams(String datacenter, ConsistencyMode consistencyMode, long waitTime, long index, String near) {
 		this.datacenter = datacenter;
 		this.consistencyMode = consistencyMode;
 		this.waitTime = waitTime;
 		this.index = index;
+		this.near = near;
+	}
+
+	private QueryParams(String datacenter, ConsistencyMode consistencyMode, long waitTime, long index) {
+		this(datacenter, consistencyMode, waitTime, index, null);
 	}
 
 	public QueryParams(String datacenter) {
@@ -84,10 +96,7 @@ public final class QueryParams implements UrlParameters {
 	}
 
     public QueryParams(String datacenter, long waitTime, long index) {
-        this.datacenter = datacenter;
-        this.consistencyMode = ConsistencyMode.DEFAULT;
-        this.waitTime = waitTime;
-        this.index = index;
+		this(datacenter, ConsistencyMode.DEFAULT, waitTime, index, null);
     }
 
 	public String getDatacenter() {
@@ -104,6 +113,10 @@ public final class QueryParams implements UrlParameters {
 
 	public long getIndex() {
 		return index;
+	}
+
+	public String getNear() {
+		return near;
 	}
 
 	@Override
@@ -124,6 +137,10 @@ public final class QueryParams implements UrlParameters {
 		}
 		if (index != -1) {
 			params.add("index=" + Utils.toUnsignedString(index));
+		}
+
+		if (near != null) {
+			params.add("near=" + Utils.encodeValue(near));
 		}
 
 		return params;

--- a/src/main/java/com/ecwid/consul/v1/QueryParams.java
+++ b/src/main/java/com/ecwid/consul/v1/QueryParams.java
@@ -133,8 +133,9 @@ public final class QueryParams implements UrlParameters {
 		}
 
 		if (waitTime != -1) {
-			params.add("wait=" + waitTime + "s");
+			params.add("wait=" + Utils.toSecondsString(waitTime));
 		}
+
 		if (index != -1) {
 			params.add("index=" + Utils.toUnsignedString(index));
 		}

--- a/src/test/java/com/ecwid/consul/UtilsTest.java
+++ b/src/test/java/com/ecwid/consul/UtilsTest.java
@@ -3,20 +3,22 @@ package com.ecwid.consul;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class UtilsTest {
 
 	@Test
 	public void testGenerateUrl_Simple() throws Exception {
-		Assert.assertEquals("/some-url", Utils.generateUrl("/some-url"));
-		Assert.assertEquals("/some-url", Utils.generateUrl("/some-url", (UrlParameters) null));
-		Assert.assertEquals("/some-url", Utils.generateUrl("/some-url", null, null));
+		assertEquals("/some-url", Utils.generateUrl("/some-url"));
+		assertEquals("/some-url", Utils.generateUrl("/some-url", (UrlParameters) null));
+		assertEquals("/some-url", Utils.generateUrl("/some-url", null, null));
 	}
 
 	@Test
 	public void testGenerateUrl_Parametrized() throws Exception {
 		UrlParameters first = new SingleUrlParameters("key", "value");
 		UrlParameters second = new SingleUrlParameters("key2");
-		Assert.assertEquals("/some-url?key=value&key2", Utils.generateUrl("/some-url", first, second));
+		assertEquals("/some-url?key=value&key2", Utils.generateUrl("/some-url", first, second));
 	}
 
 	@Test
@@ -24,7 +26,7 @@ public class UtilsTest {
 		UrlParameters first = new SingleUrlParameters("key", "value value");
 		UrlParameters second = new SingleUrlParameters("key2");
 		UrlParameters third = new SingleUrlParameters("key3", "value!value");
-		Assert.assertEquals("/some-url?key=value+value&key2&key3=value%21value", Utils.generateUrl("/some-url", first, second, third));
+		assertEquals("/some-url?key=value+value&key2&key3=value%21value", Utils.generateUrl("/some-url", first, second, third));
 	}
 
 	@Test
@@ -46,4 +48,9 @@ public class UtilsTest {
 			}
 		}
 	}
+
+    @Test
+    public void testToSecondsString() throws Exception {
+        assertEquals("1000s", Utils.toSecondsString(1000L));
+    }
 }

--- a/src/test/java/com/ecwid/consul/v1/QueryParamsTest.java
+++ b/src/test/java/com/ecwid/consul/v1/QueryParamsTest.java
@@ -1,9 +1,13 @@
 package com.ecwid.consul.v1;
 
+import com.ecwid.consul.Utils;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import java.util.List;
+
 import static com.ecwid.consul.v1.QueryParams.Builder;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.*;
 
 public class QueryParamsTest {
 	@Test
@@ -11,6 +15,7 @@ public class QueryParamsTest {
 		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.DEFAULT;
 		final long EXPECTED_INDEX = -1;
 		final long EXPECTED_WAIT_TIME = -1;
+		final String EXPECTED_NEAR = null;
 
 		Builder builder = Builder.builder();
 
@@ -20,6 +25,7 @@ public class QueryParamsTest {
 		assertEquals(actual.getConsistencyMode(), EXPECTED_MODE);
 		assertEquals(actual.getWaitTime(), EXPECTED_WAIT_TIME);
 		assertEquals(actual.getIndex(), EXPECTED_INDEX);
+		assertEquals(actual.getNear(), EXPECTED_NEAR);
 	}
 
 	@Test
@@ -28,17 +34,47 @@ public class QueryParamsTest {
 		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.CONSISTENT;
 		final long EXPECTED_INDEX = 100;
 		final long EXPECTED_WAIT_TIME = 10000;
+		final String EXPECTED_NEAR = "_agent";
 
 		Builder builder = Builder.builder();
 		QueryParams actual = builder.setDatacenter(EXPECTED_DATACENTER)
-			.setConsistencyMode(EXPECTED_MODE)
-			.setWaitTime(EXPECTED_WAIT_TIME)
-			.setIndex(EXPECTED_INDEX)
-			.build();
+				.setConsistencyMode(EXPECTED_MODE)
+				.setWaitTime(EXPECTED_WAIT_TIME)
+				.setIndex(EXPECTED_INDEX)
+				.setNear(EXPECTED_NEAR)
+				.build();
 
 		assertEquals(actual.getDatacenter(), EXPECTED_DATACENTER);
 		assertEquals(actual.getConsistencyMode(), EXPECTED_MODE);
 		assertEquals(actual.getIndex(), EXPECTED_INDEX);
 		assertEquals(actual.getWaitTime(), EXPECTED_WAIT_TIME);
+		assertEquals(actual.getNear(), EXPECTED_NEAR);
+	}
+
+	@Test
+	public void queryParamsToUrlParameters_ShouldContainSetQueryParams_WithCorrectValuesApplied() {
+		// Given
+		final String EXPECTED_DATACENTER = "testDC";
+		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.CONSISTENT;
+		final long EXPECTED_WAIT = 1000L;
+		final long EXPECTED_INDEX = 2000L;
+		final String EXPECTED_NEAR = "_agent";
+
+		// When
+		List<String> urlParameters = Builder.builder()
+				.setDatacenter(EXPECTED_DATACENTER)
+				.setConsistencyMode(EXPECTED_MODE)
+				.setWaitTime(EXPECTED_WAIT)
+				.setIndex(EXPECTED_INDEX)
+				.setNear(EXPECTED_NEAR)
+				.build()
+				.toUrlParameters();
+
+		// Then
+		assertThat(urlParameters, hasItem("dc=" + EXPECTED_DATACENTER));
+		assertThat(urlParameters, hasItem(EXPECTED_MODE.name().toLowerCase()));
+		assertThat(urlParameters, hasItem("wait=" + Utils.toSecondsString(EXPECTED_WAIT)));
+		assertThat(urlParameters, hasItem("index=" + EXPECTED_INDEX));
+		assertThat(urlParameters, hasItem("near=" + EXPECTED_NEAR));
 	}
 }

--- a/src/test/java/com/ecwid/consul/v1/QueryParamsTest.java
+++ b/src/test/java/com/ecwid/consul/v1/QueryParamsTest.java
@@ -12,15 +12,16 @@ import static org.junit.Assert.*;
 public class QueryParamsTest {
 	@Test
 	public void queryParamsBuilder_ShouldReturnAllDefaults_WhenNoValuesAdded() {
+		// Given
 		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.DEFAULT;
 		final long EXPECTED_INDEX = -1;
 		final long EXPECTED_WAIT_TIME = -1;
 		final String EXPECTED_NEAR = null;
 
-		Builder builder = Builder.builder();
+		// When
+		QueryParams actual = Builder.builder().build();
 
-		QueryParams actual = builder.build();
-
+		// Then
 		assertNull(actual.getDatacenter());
 		assertEquals(actual.getConsistencyMode(), EXPECTED_MODE);
 		assertEquals(actual.getWaitTime(), EXPECTED_WAIT_TIME);
@@ -30,20 +31,23 @@ public class QueryParamsTest {
 
 	@Test
 	public void queryParamsBuilder_ShouldReturnQueryParams_WithCorrectValuesApplied() {
+		// Given
 		final String EXPECTED_DATACENTER = "testDC";
 		final ConsistencyMode EXPECTED_MODE = ConsistencyMode.CONSISTENT;
 		final long EXPECTED_INDEX = 100;
 		final long EXPECTED_WAIT_TIME = 10000;
 		final String EXPECTED_NEAR = "_agent";
 
-		Builder builder = Builder.builder();
-		QueryParams actual = builder.setDatacenter(EXPECTED_DATACENTER)
+		// When
+		QueryParams actual = Builder.builder()
+				.setDatacenter(EXPECTED_DATACENTER)
 				.setConsistencyMode(EXPECTED_MODE)
 				.setWaitTime(EXPECTED_WAIT_TIME)
 				.setIndex(EXPECTED_INDEX)
 				.setNear(EXPECTED_NEAR)
 				.build();
 
+		// Then
 		assertEquals(actual.getDatacenter(), EXPECTED_DATACENTER);
 		assertEquals(actual.getConsistencyMode(), EXPECTED_MODE);
 		assertEquals(actual.getIndex(), EXPECTED_INDEX);


### PR DESCRIPTION
Added "near" query parameter for /v1/catalog/nodes and /v1/catalog/service/<service> requests to `QueryParams`.