### PR TITLE
Added "path" field to ConsulRawClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,12 @@ repositories {
 
 dependencies {
 	compile "com.google.code.gson:gson:2.3"
-
+	compile "org.apache.commons:commons-lang3:3.0"
 	compile "org.apache.httpcomponents:httpcore:4.4.5"
 	compile "org.apache.httpcomponents:httpclient:4.5.2"
 
-	testCompile "junit:junit:4.11"
+	testCompile "junit:junit:4.12"
+	testCompile "org.mockito:mockito-core:2.8.9"
 }
 
 // --------------------------------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ repositories {
 
 dependencies {
 	compile "com.google.code.gson:gson:2.3"
-	compile "org.apache.commons:commons-lang3:3.0"
 	compile "org.apache.httpcomponents:httpcore:4.4.5"
 	compile "org.apache.httpcomponents:httpclient:4.5.2"
 

--- a/src/main/java/com/ecwid/consul/Utils.java
+++ b/src/main/java/com/ecwid/consul/Utils.java
@@ -1,5 +1,7 @@
 package com.ecwid.consul;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -82,5 +84,14 @@ public class Utils {
 
 	public static String toSecondsString(long waitTime) {
 		return String.valueOf(waitTime) + "s";
+	}
+
+	public static String assembleAgentAddress(String host, int port, String path) {
+		String agentPath = StringUtils.EMPTY;
+		if (StringUtils.isNotBlank(path)) {
+			agentPath = "/" + path;
+		}
+
+		return String.format("%s:%d%s", host, port, agentPath);
 	}
 }

--- a/src/main/java/com/ecwid/consul/Utils.java
+++ b/src/main/java/com/ecwid/consul/Utils.java
@@ -1,7 +1,5 @@
 package com.ecwid.consul;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -87,8 +85,8 @@ public class Utils {
 	}
 
 	public static String assembleAgentAddress(String host, int port, String path) {
-		String agentPath = StringUtils.EMPTY;
-		if (StringUtils.isNotBlank(path)) {
+		String agentPath = "";
+		if (path != null && !path.trim().isEmpty()) {
 			agentPath = "/" + path;
 		}
 

--- a/src/main/java/com/ecwid/consul/v1/ConsulRawClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulRawClient.java
@@ -3,7 +3,6 @@ package com.ecwid.consul.v1;
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.Utils;
 import com.ecwid.consul.transport.*;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
 
 /**
@@ -13,7 +12,7 @@ public class ConsulRawClient {
 
 	private static final String DEFAULT_HOST = "localhost";
 	private static final int DEFAULT_PORT = 8500;
-	private static final String DEFAULT_PATH = StringUtils.EMPTY;
+	private static final String DEFAULT_PATH = "";
 
 	// one real HTTP client for all instances
 	private static final HttpTransport DEFAULT_HTTP_TRANSPORT = new DefaultHttpTransport();

--- a/src/main/java/com/ecwid/consul/v1/ConsulRawClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulRawClient.java
@@ -1,14 +1,10 @@
 package com.ecwid.consul.v1;
 
-import org.apache.http.client.HttpClient;
-
 import com.ecwid.consul.UrlParameters;
 import com.ecwid.consul.Utils;
-import com.ecwid.consul.transport.DefaultHttpTransport;
-import com.ecwid.consul.transport.DefaultHttpsTransport;
-import com.ecwid.consul.transport.HttpTransport;
-import com.ecwid.consul.transport.RawResponse;
-import com.ecwid.consul.transport.TLSConfig;
+import com.ecwid.consul.transport.*;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.HttpClient;
 
 /**
  * @author Vasily Vasilkov (vgv@ecwid.com)
@@ -17,12 +13,60 @@ public class ConsulRawClient {
 
 	private static final String DEFAULT_HOST = "localhost";
 	private static final int DEFAULT_PORT = 8500;
+	private static final String DEFAULT_PATH = StringUtils.EMPTY;
 
 	// one real HTTP client for all instances
 	private static final HttpTransport DEFAULT_HTTP_TRANSPORT = new DefaultHttpTransport();
 
 	private final HttpTransport httpTransport;
 	private final String agentAddress;
+
+	public static final class Builder {
+		private String agentHost;
+		private int agentPort;
+		private String agentPath;
+		private HttpTransport httpTransport;
+
+		public static ConsulRawClient.Builder builder() {
+			return new ConsulRawClient.Builder();
+		}
+
+		private Builder() {
+			this.agentHost = DEFAULT_HOST;
+			this.agentPort = DEFAULT_PORT;
+			this.agentPath = DEFAULT_PATH;
+			this.httpTransport = DEFAULT_HTTP_TRANSPORT;
+		}
+
+		public Builder setHost(String host) {
+			this.agentHost = host;
+			return this;
+		}
+
+		public Builder setPort(int port) {
+			this.agentPort = port;
+			return this;
+		}
+
+		public Builder setPath(String path) {
+			this.agentPath = path;
+			return this;
+		}
+
+		public Builder setTlsConfig(TLSConfig tlsConfig) {
+			this.httpTransport = new DefaultHttpsTransport(tlsConfig);
+			return this;
+		}
+
+		public Builder setHttpClient(HttpClient httpClient) {
+			this.httpTransport = new DefaultHttpTransport(httpClient);
+			return this;
+		}
+
+		public ConsulRawClient build() {
+			return new ConsulRawClient(httpTransport, agentHost, agentPort, agentPath);
+		}
+	}
 
 	public ConsulRawClient() {
 		this(DEFAULT_HOST);
@@ -41,7 +85,7 @@ public class ConsulRawClient {
 	}
 
 	public ConsulRawClient(String agentHost, int agentPort) {
-		this(DEFAULT_HTTP_TRANSPORT, agentHost, agentPort);
+		this(DEFAULT_HTTP_TRANSPORT, agentHost, agentPort, DEFAULT_PATH);
 	}
 
 	public ConsulRawClient(HttpClient httpClient) {
@@ -49,19 +93,23 @@ public class ConsulRawClient {
 	}
 
 	public ConsulRawClient(String agentHost, HttpClient httpClient) {
-		this(new DefaultHttpTransport(httpClient), agentHost, DEFAULT_PORT);
+		this(new DefaultHttpTransport(httpClient), agentHost, DEFAULT_PORT, DEFAULT_PATH);
 	}
 
 	public ConsulRawClient(String agentHost, int agentPort, HttpClient httpClient) {
-		this(new DefaultHttpTransport(httpClient), agentHost, agentPort);
+		this(new DefaultHttpTransport(httpClient), agentHost, agentPort, DEFAULT_PATH);
 	}
 
 	public ConsulRawClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
-		this(new DefaultHttpsTransport(tlsConfig), agentHost, agentPort);
+		this(new DefaultHttpsTransport(tlsConfig), agentHost, agentPort, DEFAULT_PATH);
+	}
+
+	public ConsulRawClient(HttpClient httpClient, String host, int port, String path) {
+		this(new DefaultHttpTransport(httpClient), host, port, path);
 	}
 
 	// hidden constructor, for tests
-	ConsulRawClient(HttpTransport httpTransport, String agentHost, int agentPort) {
+	ConsulRawClient(HttpTransport httpTransport, String agentHost, int agentPort, String path) {
 		this.httpTransport = httpTransport;
 
 		// check that agentHost has scheme or not
@@ -71,7 +119,7 @@ public class ConsulRawClient {
 			agentHost = "http://" + agentHost;
 		}
 
-		this.agentAddress = agentHost + ":" + agentPort;
+		this.agentAddress = Utils.assembleAgentAddress(agentHost, agentPort, path);
 	}
 
 	public RawResponse makeGetRequest(String endpoint, UrlParameters... urlParams) {

--- a/src/test/java/com/ecwid/consul/ConsulRawClientTest.java
+++ b/src/test/java/com/ecwid/consul/ConsulRawClientTest.java
@@ -1,0 +1,64 @@
+package com.ecwid.consul;
+
+import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.QueryParams;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ConsulRawClientTest {
+
+    private static final String ENDPOINT = "/any/endpoint";
+    private static final QueryParams EMPTY_QUERY_PARAMS = QueryParams.Builder.builder().build();
+    private static final String HOST = "host";
+    private static final int PORT = 8888;
+    private static final String PATH = "path";
+    private static final String EXPECTED_AGENT_ADDRESS_NO_PATH = "http://" + HOST + ":"+ PORT + ENDPOINT;
+    private static final String EXPECTED_AGENT_ADDRESS = "http://" + HOST + ":"+ PORT + "/" + PATH + ENDPOINT;
+
+    @Test
+    public void verifyDefaultUrl() throws Exception {
+        // Given
+        HttpClient httpClient = mock(HttpClient.class);
+        ConsulRawClient client = ConsulRawClient.Builder.builder()
+                .setHttpClient(httpClient)
+                .setHost(HOST)
+                .setPort(PORT)
+                .build();
+
+        // When
+        client.makeGetRequest(ENDPOINT, EMPTY_QUERY_PARAMS);
+
+        // Then
+        ArgumentCaptor<HttpUriRequest> calledUri = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(httpClient).execute(calledUri.capture(), any(ResponseHandler.class));
+        assertEquals(EXPECTED_AGENT_ADDRESS_NO_PATH, calledUri.getValue().getURI().toString());
+    }
+
+    @Test
+    public void verifyUrlWithPath() throws Exception {
+        // Given
+        HttpClient httpClient = mock(HttpClient.class);
+        ConsulRawClient client = ConsulRawClient.Builder.builder()
+                .setHttpClient(httpClient)
+                .setHost(HOST)
+                .setPort(PORT)
+                .setPath(PATH)
+                .build();
+
+        // When
+        client.makeGetRequest(ENDPOINT, EMPTY_QUERY_PARAMS);
+
+        // Then
+        ArgumentCaptor<HttpUriRequest> calledUri = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(httpClient).execute(calledUri.capture(), any(ResponseHandler.class));
+        assertEquals(EXPECTED_AGENT_ADDRESS, calledUri.getValue().getURI().toString());
+    }
+}

--- a/src/test/java/com/ecwid/consul/UtilsTest.java
+++ b/src/test/java/com/ecwid/consul/UtilsTest.java
@@ -53,4 +53,37 @@ public class UtilsTest {
     public void testToSecondsString() throws Exception {
         assertEquals("1000s", Utils.toSecondsString(1000L));
     }
+
+	@Test
+	public void testAssembleAgentAddressWithPath() {
+		// Given
+		String expectedHost = "http://host";
+		int expectedPort = 8888;
+		String expectedPath = "path";
+
+		// When
+		String actualAddress = Utils.assembleAgentAddress(expectedHost, expectedPort, expectedPath);
+
+		// Then
+		assertEquals(
+				String.format("%s:%d/%s", expectedHost, expectedPort, expectedPath),
+				actualAddress
+		);
+	}
+
+	@Test
+	public void testAssembleAgentAddressWithoutPath() {
+		// Given
+		String expectedHost = "https://host";
+		int expectedPort = 8888;
+
+		// When
+		String actualAddress = Utils.assembleAgentAddress(expectedHost, expectedPort, null);
+
+		// Then
+		assertEquals(
+				String.format("%s:%d", expectedHost, expectedPort),
+				actualAddress
+		);
+	}
 }

--- a/src/test/java/com/ecwid/consul/UtilsTest.java
+++ b/src/test/java/com/ecwid/consul/UtilsTest.java
@@ -72,6 +72,23 @@ public class UtilsTest {
 	}
 
 	@Test
+	public void testAssembleAgentAddressWithEmptyPath() {
+		// Given
+		String expectedHost = "http://host";
+		int expectedPort = 8888;
+		String expectedPath = "   ";
+
+		// When
+		String actualAddress = Utils.assembleAgentAddress(expectedHost, expectedPort, expectedPath);
+
+		// Then
+		assertEquals(
+				String.format("%s:%d", expectedHost, expectedPort),
+				actualAddress
+		);
+	}
+
+	@Test
 	public void testAssembleAgentAddressWithoutPath() {
 		// Given
 		String expectedHost = "https://host";


### PR DESCRIPTION
Added "path" field to `ConsulRawClient` to access Consul behind a proxy as mentiond in #77. I also implemented a `Builder` in `ConsulRawClient` to allow easier configuration of a client.