### PR TITLE
Partial fix #91 - Add support for executing prepared queries

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/ConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/ConsulClient.java
@@ -27,6 +27,9 @@ import com.ecwid.consul.v1.kv.KeyValueConsulClient;
 import com.ecwid.consul.v1.kv.model.GetBinaryValue;
 import com.ecwid.consul.v1.kv.model.GetValue;
 import com.ecwid.consul.v1.kv.model.PutParams;
+import com.ecwid.consul.v1.query.QueryClient;
+import com.ecwid.consul.v1.query.QueryConsulClient;
+import com.ecwid.consul.v1.query.model.QueryExecution;
 import com.ecwid.consul.v1.session.SessionClient;
 import com.ecwid.consul.v1.session.SessionConsulClient;
 import com.ecwid.consul.v1.session.model.NewSession;
@@ -55,6 +58,7 @@ public class ConsulClient implements
 		EventClient,
 		HealthClient,
 		KeyValueClient,
+		QueryClient,
 		SessionClient,
 		StatusClient {
 
@@ -65,6 +69,7 @@ public class ConsulClient implements
 	private final EventClient eventClient;
 	private final HealthClient healthClient;
 	private final KeyValueClient keyValueClient;
+	private final QueryClient queryClient;
 	private final SessionClient sessionClient;
 	private final StatusClient statusClient;
 
@@ -76,6 +81,7 @@ public class ConsulClient implements
 		eventClient = new EventConsulClient(rawClient);
 		healthClient = new HealthConsulClient(rawClient);
 		keyValueClient = new KeyValueConsulClient(rawClient);
+		queryClient = new QueryConsulClient(rawClient);
 		sessionClient = new SessionConsulClient(rawClient);
 		statusClient = new StatusConsulClient(rawClient);
 	}
@@ -640,6 +646,14 @@ public class ConsulClient implements
 	@Override
 	public Response<Void> deleteKVValues(String key, String token, QueryParams queryParams) {
 		return keyValueClient.deleteKVValues(key, token, queryParams);
+	}
+
+	// -------------------------------------------------------------------------------------------
+	// Prepared Query
+
+	@Override
+	public Response<QueryExecution> executePreparedQuery(String uuid, QueryParams queryParams) {
+		return queryClient.executePreparedQuery(uuid, queryParams);
 	}
 
 	// -------------------------------------------------------------------------------------------

--- a/src/main/java/com/ecwid/consul/v1/query/QueryClient.java
+++ b/src/main/java/com/ecwid/consul/v1/query/QueryClient.java
@@ -1,0 +1,10 @@
+package com.ecwid.consul.v1.query;
+
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.query.model.QueryExecution;
+
+public interface QueryClient {
+
+	public Response<QueryExecution> executePreparedQuery(String uuid, QueryParams queryParams);
+}

--- a/src/main/java/com/ecwid/consul/v1/query/QueryConsulClient.java
+++ b/src/main/java/com/ecwid/consul/v1/query/QueryConsulClient.java
@@ -1,0 +1,49 @@
+package com.ecwid.consul.v1.query;
+
+import com.ecwid.consul.json.GsonFactory;
+import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.TLSConfig;
+import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.OperationException;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.query.model.QueryExecution;
+
+public final class QueryConsulClient implements QueryClient {
+
+	private final ConsulRawClient rawClient;
+
+	public QueryConsulClient(ConsulRawClient rawClient) { this.rawClient = rawClient; }
+
+	public QueryConsulClient() { this(new ConsulRawClient()); }
+
+	public QueryConsulClient(TLSConfig tlsConfig) { this(new ConsulRawClient(tlsConfig)); }
+
+	public QueryConsulClient(String agentHost) {
+		this(new ConsulRawClient(agentHost));
+	}
+
+	public QueryConsulClient(String agentHost, TLSConfig tlsConfig) {
+		this(new ConsulRawClient(agentHost, tlsConfig));
+	}
+
+	public QueryConsulClient(String agentHost, int agentPort) {
+		this(new ConsulRawClient(agentHost, agentPort));
+	}
+
+	public QueryConsulClient(String agentHost, int agentPort, TLSConfig tlsConfig) {
+		this(new ConsulRawClient(agentHost, agentPort, tlsConfig));
+	}
+
+	@Override
+	public Response<QueryExecution> executePreparedQuery(String uuid, QueryParams queryParams) {
+		RawResponse rawResponse = rawClient.makeGetRequest("/v1/query/" + uuid + "/execute", queryParams);
+
+		if (rawResponse.getStatusCode() == 200) {
+			QueryExecution queryExecution = GsonFactory.getGson().fromJson(rawResponse.getContent(), QueryExecution.class);
+			return new Response<QueryExecution>(queryExecution, rawResponse);
+		} else {
+			throw new OperationException(rawResponse);
+		}
+	}
+}

--- a/src/main/java/com/ecwid/consul/v1/query/model/Check.java
+++ b/src/main/java/com/ecwid/consul/v1/query/model/Check.java
@@ -1,0 +1,160 @@
+package com.ecwid.consul.v1.query.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * @author Vasily Vasilkov (vgv@ecwid.com)
+ */
+public class Check {
+
+	public static enum CheckStatus {
+		@SerializedName("unknown")
+		UNKNOWN,
+		@SerializedName("passing")
+		PASSING,
+		@SerializedName("warning")
+		WARNING,
+		@SerializedName("critical")
+		CRITICAL
+	}
+
+	@SerializedName("Node")
+	private String node;
+
+	@SerializedName("CheckID")
+	private String checkId;
+
+	@SerializedName("Name")
+	private String name;
+
+	@SerializedName("Status")
+	private CheckStatus status;
+
+	@SerializedName("Notes")
+	private String notes;
+
+	@SerializedName("Output")
+	private String output;
+
+	@SerializedName("ServiceID")
+	private String serviceId;
+
+	@SerializedName("ServiceName")
+	private String serviceName;
+
+	@SerializedName("ServiceTags")
+	private List<String> serviceTags;
+
+	@SerializedName("CreateIndex")
+	private Long createIndex;
+
+	@SerializedName("ModifyIndex")
+	private Long modifyIndex;
+
+	public String getNode() {
+		return node;
+	}
+
+	public void setNode(String node) {
+		this.node = node;
+	}
+
+	public String getCheckId() {
+		return checkId;
+	}
+
+	public void setCheckId(String checkId) {
+		this.checkId = checkId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public CheckStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(CheckStatus status) {
+		this.status = status;
+	}
+
+	public String getNotes() {
+		return notes;
+	}
+
+	public void setNotes(String notes) {
+		this.notes = notes;
+	}
+
+	public String getOutput() {
+		return output;
+	}
+
+	public void setOutput(String output) {
+		this.output = output;
+	}
+
+	public String getServiceId() {
+		return serviceId;
+	}
+
+	public void setServiceId(String serviceId) {
+		this.serviceId = serviceId;
+	}
+
+	public String getServiceName() {
+		return serviceName;
+	}
+
+	public void setServiceName(String serviceName) {
+		this.serviceName = serviceName;
+	}
+
+	public List<String> getServiceTags() {
+		return serviceTags;
+	}
+
+	public void setServiceTags(List<String> serviceTags) {
+		this.serviceTags = serviceTags;
+	}
+
+	public Long getCreateIndex() {
+		return createIndex;
+	}
+
+	public void setCreateIndex(Long createIndex) {
+		this.createIndex = createIndex;
+	}
+
+	public Long getModifyIndex() {
+		return modifyIndex;
+	}
+
+	public void setModifyIndex(Long modifyIndex) {
+		this.modifyIndex = modifyIndex;
+	}
+
+	@Override
+	public String toString() {
+		return "Check{" +
+				"node='" + node + '\'' +
+				", checkId='" + checkId + '\'' +
+				", name='" + name + '\'' +
+				", status=" + status +
+				", notes='" + notes + '\'' +
+				", output='" + output + '\'' +
+				", serviceId='" + serviceId + '\'' +
+				", serviceName='" + serviceName + '\'' +
+				", serviceTags=" + serviceTags +
+				", createIndex=" + createIndex +
+				", modifyIndex=" + modifyIndex +
+				'}';
+	}
+}

--- a/src/main/java/com/ecwid/consul/v1/query/model/QueryExecution.java
+++ b/src/main/java/com/ecwid/consul/v1/query/model/QueryExecution.java
@@ -1,0 +1,66 @@
+package com.ecwid.consul.v1.query.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class QueryExecution {
+
+	public static class DNS {
+		@SerializedName("TTL")
+		private String ttl;
+
+		public String getTtl() { return ttl; }
+
+		public void setTtl(String ttl) { this.ttl = ttl; }
+
+		@Override
+		public String toString() {
+			return "DNS{" +
+				"ttl=" + ttl +
+				'}';
+		}
+	}
+
+	@SerializedName("Service")
+	private String service;
+
+	@SerializedName("Nodes")
+	private List<QueryNode> nodes;
+
+	@SerializedName("DNS")
+	private DNS dns;
+
+	@SerializedName("Datacenter")
+	private String datacenter;
+
+	@SerializedName("Failovers")
+	private Integer failovers;
+
+	public String getService() { return service; }
+
+	public void setService(String service) { this.service = service; }
+
+	public List<QueryNode> getNodes() { return nodes; }
+
+	public void setNodes(List<QueryNode> nodes) { this.nodes = nodes; }
+
+	public String getDatacenter() { return datacenter; }
+
+	public void setDatacenter(String datacenter) { this.datacenter = datacenter; }
+
+	public Integer getFailovers() { return failovers; }
+
+	public void setFailovers(Integer failovers) { this.failovers = failovers; }
+
+	@Override
+	public String toString() {
+		return "CatalogNode{" +
+			"service=" + service +
+			", nodes=" + nodes +
+			", dns=" + dns +
+			", datacenter=" + datacenter +
+			", failovers=" + failovers +
+			'}';
+	}
+}

--- a/src/main/java/com/ecwid/consul/v1/query/model/QueryNode.java
+++ b/src/main/java/com/ecwid/consul/v1/query/model/QueryNode.java
@@ -244,6 +244,4 @@ public class QueryNode {
 			", checks=" + checks +
 			'}';
 	}
-
-
 }

--- a/src/main/java/com/ecwid/consul/v1/query/model/QueryNode.java
+++ b/src/main/java/com/ecwid/consul/v1/query/model/QueryNode.java
@@ -1,0 +1,249 @@
+package com.ecwid.consul.v1.query.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+import java.util.Map;
+
+public class QueryNode {
+
+	public static class Node {
+		@SerializedName("ID")
+		private String id;
+
+		@SerializedName("Node")
+		private String node;
+
+		@SerializedName("Address")
+		private String address;
+
+		@SerializedName("Datacenter")
+		private String datacenter;
+
+		@SerializedName("TaggedAddresses")
+		private Map<String, String> taggedAddresses;
+
+		@SerializedName("Meta")
+		private Map<String, String> meta;
+
+		@SerializedName("CreateIndex")
+		private Long createIndex;
+
+		@SerializedName("ModifyIndex")
+		private Long modifyIndex;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getNode() {
+			return node;
+		}
+
+		public void setNode(String node) {
+			this.node = node;
+		}
+
+		public String getAddress() {
+			return address;
+		}
+
+		public void setAddress(String address) {
+			this.address = address;
+		}
+
+		public String getDatacenter() {
+			return datacenter;
+		}
+
+		public void setDatacenter(String datacenter) {
+			this.datacenter = datacenter;
+		}
+
+		public Map<String, String> getTaggedAddresses() {
+			return taggedAddresses;
+		}
+
+		public void setTaggedAddresses(Map<String, String> taggedAddresses) {
+			this.taggedAddresses = taggedAddresses;
+		}
+
+		public Map<String, String> getMeta() {
+			return meta;
+		}
+
+		public void setMeta(Map<String, String> meta) {
+			this.meta = meta;
+		}
+
+		public Long getCreateIndex() {
+			return createIndex;
+		}
+
+		public void setCreateIndex(Long createIndex) {
+			this.createIndex = createIndex;
+		}
+
+		public Long getModifyIndex() {
+			return modifyIndex;
+		}
+
+		public void setModifyIndex(Long modifyIndex) {
+			this.modifyIndex = modifyIndex;
+		}
+
+		@Override
+		public String toString() {
+			return "Node{" +
+				"id='" + id + '\'' +
+				", node='" + node + '\'' +
+				", address='" + address + '\'' +
+				", datacenter='" + datacenter + '\'' +
+				", taggedAddresses=" + taggedAddresses +
+				", meta=" + meta +
+				", createIndex=" + createIndex +
+				", modifyIndex=" + modifyIndex +
+				'}';
+		}
+	}
+
+	public static class Service {
+		@SerializedName("ID")
+		private String id;
+
+		@SerializedName("Service")
+		private String service;
+
+		@SerializedName("Tags")
+		private List<String> tags;
+
+		@SerializedName("Address")
+		private String address;
+
+		@SerializedName("Port")
+		private Integer port;
+
+		@SerializedName("EnableTagOverride")
+		private Boolean enableTagOverride;
+
+		@SerializedName("CreateIndex")
+		private Long createIndex;
+
+		@SerializedName("ModifyIndex")
+		private Long modifyIndex;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getService() {
+			return service;
+		}
+
+		public void setService(String service) {
+			this.service = service;
+		}
+
+		public List<String> getTags() {
+			return tags;
+		}
+
+		public void setTags(List<String> tags) {
+			this.tags = tags;
+		}
+
+		public String getAddress() {
+			return address;
+		}
+
+		public void setAddress(String address) {
+			this.address = address;
+		}
+
+		public Integer getPort() {
+			return port;
+		}
+
+		public void setPort(Integer port) {
+			this.port = port;
+		}
+
+		public Boolean getEnableTagOverride() {
+			return enableTagOverride;
+		}
+
+		public void setEnableTagOverride(Boolean enableTagOverride) {
+			this.enableTagOverride = enableTagOverride;
+		}
+
+		public Long getCreateIndex() {
+			return createIndex;
+		}
+
+		public void setCreateIndex(Long createIndex) {
+			this.createIndex = createIndex;
+		}
+
+		public Long getModifyIndex() {
+			return modifyIndex;
+		}
+
+		public void setModifyIndex(Long modifyIndex) {
+			this.modifyIndex = modifyIndex;
+		}
+
+		@Override
+		public String toString() {
+			return "Service{" +
+				"id='" + id + '\'' +
+				", service='" + service + '\'' +
+				", tags=" + tags +
+				", address='" + address + '\'' +
+				", port=" + port +
+				", enableTagOverride=" + enableTagOverride +
+				", createIndex=" + createIndex +
+				", modifyIndex=" + modifyIndex +
+				'}';
+		}
+	}
+
+	@SerializedName("Node")
+	private Node node;
+
+	@SerializedName("Service")
+	private Service service;
+
+	@SerializedName("Checks")
+	private List<Check> checks;
+
+	public Node getNode() { return node; }
+
+	public void setNode(Node node) { this.node = node; }
+
+	public Service getService() { return service; }
+
+	public void setService(Service service) { this.service = service; }
+
+	public List<Check> getChecks() { return checks; }
+
+	public void setChecks(List<Check> checks) { this.checks = checks; }
+
+	@Override
+	public String toString() {
+		return "QueryNode{" +
+			"node=" + node +
+			", service=" + service +
+			", checks=" + checks +
+			'}';
+	}
+
+
+}


### PR DESCRIPTION
Adds QueryConsulClient with very simple method to execute prepared queries.  Tried to match [consul api ](https://www.consul.io/api/query.html#execute-prepared-query) as closely as possible but currently QueryParameters does not include [limit](https://www.consul.io/api/query.html#limit) so I left it out.

This PR is to address part of - https://github.com/Ecwid/consul-api/issues/91 - needed by @benhass and myself.

