### PR TITLE
add service meta field in Health.Service

### DIFF
--- a/src/main/java/com/ecwid/consul/v1/health/model/HealthService.java
+++ b/src/main/java/com/ecwid/consul/v1/health/model/HealthService.java
@@ -129,6 +129,9 @@ public class HealthService {
         @SerializedName("Address")
         private String address;
 
+        @SerializedName("Meta")
+        private Map<String, String> meta;
+
         @SerializedName("Port")
         private Integer port;
 
@@ -171,6 +174,14 @@ public class HealthService {
 
         public void setAddress(String address) {
             this.address = address;
+        }
+
+        public Map<String, String> getMeta() {
+            return meta;
+        }
+
+        public void setMeta(Map<String, String> meta) {
+            this.meta = meta;
         }
 
         public Integer getPort() {


### PR DESCRIPTION
When register service with class com.ecwid.consul.v1.agent.model.NewService, it contain field Map<String,String>meta . but when get health service from consul. Health.Service do not contain a field meta to receive meta data.  

This  merge add a Map<String,String>meta  field in com.ecwid.consul.v1.health.model.HealthService to receive metadata.