### PR TITLE
Upgrade httpcomponents to latest version. Fixes #211

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ repositories {
 
 dependencies {
 	implementation "com.google.code.gson:gson:2.8.2"
-	implementation "org.apache.httpcomponents:httpcore:4.4.9"
-	implementation "org.apache.httpcomponents:httpclient:4.5.5"
+	implementation "org.apache.httpcomponents:httpcore:4.4.14"
+	implementation "org.apache.httpcomponents:httpclient:4.5.13"
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'


### PR DESCRIPTION
httpclient up to version 4.5.13 (exluding) has known vulnerability CVE-2020-13956