### PR TITLE
Add jaxb-api dependency to support java>=11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ jdk:
   - openjdk10
   - openjdk11
   - openjdk12
+  - openjdk13
+  - openjdk17
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 consul-api
 ==========
 
-[![Build Status](https://api.travis-ci.org/Ecwid/consul-api.svg)](http://travis-ci.org/Ecwid/consul-api)
+[![Build Status](https://api.travis-ci.com/Ecwid/consul-api.svg)](https://app.travis-ci.com/Ecwid/consul-api)
 
 Java client for Consul HTTP API (http://consul.io)
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	implementation "com.google.code.gson:gson:2.8.9"
 	implementation "org.apache.httpcomponents:httpcore:4.4.9"
 	implementation "org.apache.httpcomponents:httpclient:4.5.5"
+	implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.6"
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'


### PR DESCRIPTION
jaxb has been removed from jdk >=11. Explicitly add dependency to correct ClassNotFound exception from KV GetValue